### PR TITLE
Implement global XSS escaping

### DIFF
--- a/includes/config.inc.php
+++ b/includes/config.inc.php
@@ -93,6 +93,7 @@ $config['recaptcha'] = [
 
 // ==== Smarty Initialisierung ====
 $smarty = new Smarty();
+$smarty->escape_html = true;
 
 $smarty->setTemplateDir(__DIR__ . '/../templates/');
 $smarty->setCompileDir(__DIR__ . '/../templates_c/');

--- a/public/admin_logs.php
+++ b/public/admin_logs.php
@@ -18,6 +18,7 @@ use Smarty\Smarty;
 
 /** @var Smarty $smarty */
 $smarty = new Smarty();
+$smarty->escape_html = true;
 
 // Standard-SMARTY-Einstellungen
 $smarty->setTemplateDir(__DIR__ . '/../templates/');

--- a/templates/dashboard.tpl
+++ b/templates/dashboard.tpl
@@ -5,7 +5,7 @@
 {block name="content"}
 <div class="container mt-5">
   <h1>
-    Hallo, {$username}!<br>
+    Hallo, {$username|escape}!<br>
     <small class="text-muted">
         Rolle:
         {if $isAdmin}

--- a/templates/layouts/layout.tpl
+++ b/templates/layouts/layout.tpl
@@ -29,7 +29,7 @@
   </div>
   <nav class="header-auth-links">
     {if $isLoggedIn}
-      <span class="me-3">Willkommen, {$username}!</span>
+      <span class="me-3">Willkommen, {$username|escape}!</span>
       <a href="{$base_url}/logout.php" class="btn btn-sm btn-outline-secondary">Logout</a>
     {else}
       <a href="#" class="btn btn-sm btn-primary me-2" data-bs-toggle="modal" data-bs-target="#loginModal">Login</a>

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -11,7 +11,7 @@
         <p class="text-muted">Max</p>
 
         <strong>Benutzername:</strong>
-        <p class="text-muted">{$username}</p>
+        <p class="text-muted">{$username|escape}</p>
 
         <strong>E-Mail:</strong>
         <p class="text-muted">max@example.com</p>


### PR DESCRIPTION
## Summary
- enable automatic HTML escaping in Smarty configuration
- escape usernames in layout, dashboard and profile templates
- ensure admin logs also uses Smarty's escape_html

## Testing
- `composer validate --no-check-all --strict` *(fails: composer not installed)*
- `php -l includes/config.inc.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842d94cd4408332bec96e1eca1a1e32