### PR TITLE
Restrict upload types

### DIFF
--- a/public/upload.php
+++ b/public/upload.php
@@ -41,13 +41,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $file     = $_FILES['file'];
             $finfo    = new finfo(FILEINFO_MIME_TYPE);
             $mimeType = $finfo->file($file['tmp_name']);
-            $allowed  = ['application/pdf','image/jpeg','image/png','text/plain'];
+            $allowed  = [
+                'application/pdf',
+                'image/jpeg',
+                'image/png',
+                'text/plain',
+                'application/msword',
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                'application/vnd.oasis.opendocument.text',
+                'application/vnd.ms-powerpoint',
+                'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+            ];
 
             if ($file['error'] !== UPLOAD_ERR_OK) {
                 $error = 'Fehler beim Datei-Upload.';
                 $log->error('Datei-Upload-Fehler', ['user_id' => $_SESSION['user_id'], 'error' => $file['error']]);
             } elseif (!in_array($mimeType, $allowed, true)) {
-                $error = 'Nur PDF, JPG, PNG und TXT erlaubt.';
+                $error = 'Nur PDF, JPG, PNG, TXT, DOC, DOCX, ODT, PPT und PPTX erlaubt.';
             } elseif ($file['size'] > 10 * 1024 * 1024) {
                 $error = 'Maximal 10 MB erlaubt.';
             } else {

--- a/templates/upload.tpl
+++ b/templates/upload.tpl
@@ -44,7 +44,7 @@
         <div class="mb-3">
             <label for="file" class="form-label">Datei auswählen</label>
             <input type="file" id="file" name="file" class="form-control" accept=".pdf,.jpg,.jpeg,.png,.txt" required>
-            <div class="form-text">Erlaubte Dateitypen: PDF, JPG, PNG, TXT. Max. 10 MB.</div>
+            <div class="form-text">Erlaubte Dateitypen: PDF, JPG, PNG, TXT, DOC, DOCX, ODT, PPT Max. 10 MB.</div>
         </div>
 
         <button type="submit" class="btn btn-primary">Hochladen</button>


### PR DESCRIPTION
## Summary
- allow DOC, DOCX, ODT, PPT and PPTX uploads
- update the upload error message

## Testing
- `php -l public/upload.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843432e1b708332bce18e65545b33db