### PR TITLE
Integrate profile handling

### DIFF
--- a/public/edit_profile.php
+++ b/public/edit_profile.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+session_start();
+
+if (empty($_SESSION['user_id']) || empty($_SESSION['username'])) {
+    $reason = urlencode("Du musst eingeloggt sein, um dein Profil zu bearbeiten.");
+    header("Location: /studyhub/error/403?reason={$reason}&action=both");
+    exit;
+}
+
+require_once __DIR__ . '/../includes/config.inc.php';
+require_once __DIR__ . '/../includes/db.inc.php';
+
+$userId   = $_SESSION['user_id'];
+$username = $_SESSION['username'];
+
+// Profildaten laden
+$profile = DbFunctions::getOrCreateUserProfile($userId);
+
+
+
+// Smarty-Zuweisungen
+$smarty->assign('base_url', $config['base_url']);
+$smarty->assign('app_name', $config['app_name']);
+$smarty->assign('isLoggedIn', true);
+$smarty->assign('username', $username);
+$smarty->assign('profile', $profile);
+
+// Template anzeigen
+$smarty->display('edit_profile.tpl');
+
+

--- a/public/profile.php
+++ b/public/profile.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 // Zentrale Initialisierung
 require_once __DIR__ . '/../includes/config.inc.php';
+require_once __DIR__ . '/../includes/db.inc.php';
 
 // Login-Schutz
 if (empty($_SESSION['user_id']) || empty($_SESSION['username'])) {
@@ -10,7 +11,11 @@ if (empty($_SESSION['user_id']) || empty($_SESSION['username'])) {
     exit;
 }
 
+$userId   = $_SESSION['user_id'];
 $username = $_SESSION['username'];
+
+// Profilinformationen laden oder bei Bedarf erstellen
+$profile = DbFunctions::getOrCreateUserProfile($userId);
 
 // ❗ 2FA-Logik nur hier gezielt einbinden
 require_once __DIR__ . '/../includes/2fa.inc.php';
@@ -20,6 +25,7 @@ $smarty->assign('base_url', $config['base_url']);
 $smarty->assign('app_name', $config['app_name']);
 $smarty->assign('isLoggedIn', true);
 $smarty->assign('username', $username);
+$smarty->assign('profile', $profile);
 
 // Seite anzeigen
 $smarty->display('profile.tpl');

--- a/public/saveprofile.php
+++ b/public/saveprofile.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+require_once __DIR__ . '/../includes/config.inc.php';
+require_once __DIR__ . '/../includes/db.inc.php';
+
+if (empty($_SESSION['user_id'])) {
+    http_response_code(403);
+    exit('Nicht eingeloggt.');
+}
+
+$userId = $_SESSION['user_id'];
+
+// POST-Daten holen und vorbereiten
+$data = [];
+$keys = ['first_name', 'last_name', 'birthdate', 'location', 'about_me', 'instagram', 'tiktok', 'discord', 'ms_teams'];
+
+foreach ($keys as $key) {
+    $value = $_POST[$key] ?? null;
+    
+    if ($key === 'birthdate' && trim($value) === '') {
+        $data[$key] = null;
+    } else {
+        $data[$key] = trim($value);
+    }
+}
+
+// Optional: Profilbild-Upload verarbeiten
+if (!empty($_FILES['profile_picture']) && $_FILES['profile_picture']['error'] === UPLOAD_ERR_OK) {
+    $tmpName = $_FILES['profile_picture']['tmp_name'];
+    $ext = strtolower(pathinfo($_FILES['profile_picture']['name'], PATHINFO_EXTENSION));
+    $mimeType = mime_content_type($tmpName);
+    
+    $allowedTypes = ['image/jpeg', 'image/png', 'image/gif'];
+    if (!in_array($mimeType, $allowedTypes)) {
+        exit('❌ Ungültiger Bildtyp.');
+    }
+    
+    // Zielverzeichnis und Dateiname
+    $uploadDir = __DIR__ . '/../uploads/profile_pictures/';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0775, true);
+    }
+    
+    $fileName = uniqid('profile_', true) . '.' . $ext;
+    $targetPath = $uploadDir . $fileName;
+    
+    if (move_uploaded_file($tmpName, $targetPath)) {
+        $data['profile_picture'] = $fileName;
+    } else {
+        exit('❌ Fehler beim Hochladen des Bildes.');
+    }
+}
+
+// Speichern in DB
+DbFunctions::updateUserProfile($userId, $data);
+
+// Weiterleitung
+header('Location: /iksy05/StudyHub/public/profile.php?success=1');
+exit;

--- a/templates/edit_profile.tpl
+++ b/templates/edit_profile.tpl
@@ -1,0 +1,68 @@
+{extends file="./layouts/layout.tpl"}
+
+{block name="title"}Profil bearbeiten{/block}
+
+{block name="content"}
+<h1 class="text-center">Profil bearbeiten</h1>
+
+<div class="container my-5">
+    <form method="post" action="saveprofile.php" enctype="multipart/form-data" class="card p-4">
+
+        <div class="mb-3">
+            <label for="first_name" class="form-label">Vorname</label>
+            <input type="text" class="form-control" name="first_name" value="{$profile.first_name}">
+        </div>
+
+        <div class="mb-3">
+            <label for="last_name" class="form-label">Nachname</label>
+            <input type="text" class="form-control" name="last_name" value="{$profile.last_name}">
+        </div>
+
+        <div class="mb-3">
+            <label for="birthdate" class="form-label">Geburtsdatum</label>
+            <input type="date" class="form-control" name="birthdate" value="{$profile.birthdate}">
+        </div>
+
+        <div class="mb-3">
+            <label for="location" class="form-label">Wohnort</label>
+            <input type="text" class="form-control" name="location" value="{$profile.location}">
+        </div>
+
+        <div class="mb-3">
+            <label for="about_me" class="form-label">Über mich</label>
+            <textarea class="form-control" name="about_me" rows="4">{$profile.about_me}</textarea>
+        </div>
+
+        <div class="mb-3">
+            <label for="instagram" class="form-label">Instagram</label>
+            <input type="text" class="form-control" name="instagram" value="{$profile.instagram}">
+        </div>
+
+        <div class="mb-3">
+            <label for="tiktok" class="form-label">TikTok</label>
+            <input type="text" class="form-control" name="tiktok" value="{$profile.tiktok}">
+        </div>
+
+        <div class="mb-3">
+            <label for="discord" class="form-label">Discord</label>
+            <input type="text" class="form-control" name="discord" value="{$profile.discord}">
+        </div>
+
+        <div class="mb-3">
+            <label for="ms_teams" class="form-label">MS Teams</label>
+            <input type="text" class="form-control" name="ms_teams" value="{$profile.ms_teams}">
+        </div>
+
+        <div class="mb-3">
+            <label for="profile_picture" class="form-label">Neues Profilbild</label>
+            <input type="file" class="form-control" name="profile_picture" accept="image/*">
+        </div>
+
+        <button type="submit" class="btn btn-success">Speichern</button>
+    </form>
+</div>
+{if $smarty.get.success == 1}
+<div class="alert alert-success">Profil wurde erfolgreich gespeichert.</div>
+{/if}
+
+{/block}

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -7,20 +7,57 @@
 
 <div class="container my-5">
     <div class="profile-box">
-        <strong>Name:</strong>
-        <p class="text-muted">Max</p>
+      
+        {* PROFILBILD *}
+{if $profile.profile_picture}
+    <div class="text-center mb-4">
+        <img src="{$base_url}/uploads/profile_pictures/{$profile.profile_picture}" alt="Profilbild" class="rounded-circle shadow" style="max-width: 150px;">
+    </div>
+{else}
+    <div class="text-center mb-4">
+        <img src="{$base_url}/images/default-profile.png" alt="Kein Profilbild" class="rounded-circle shadow" style="max-width: 150px;">
+    </div>
+{/if}
 
-        <strong>Benutzername:</strong>
-        <p class="text-muted">{$username}</p>
+       
 
-        <strong>E-Mail:</strong>
-        <p class="text-muted">max@example.com</p>
+        {* PERSÖNLICHE INFOS *}
+        <div class="card mb-4">
+            <div class="card-body">
+                
 
-        <strong>Andere Netzwerke:</strong>
-        <p class="text-muted">Instagram, TikTok, Discord, MS Teams</p>
+                <strong>Benutzername:</strong>
+                <p class="text-muted">{$username}</p>
+
+                <strong>Vorname:</strong>
+                <p class="text-muted">{$profile.first_name}</p>
+
+                <strong>Nachname:</strong>
+                <p class="text-muted">{$profile.last_name}</p>
+
+                <strong>Geburtsdatum:</strong>
+                <p class="text-muted">
+                    {if $profile.birthdate}{$profile.birthdate|date_format:"%d.%m.%Y"}{else}-{/if}
+                </p>
+
+                <strong>Wohnort:</strong>
+                <p class="text-muted">{$profile.location}</p>
+
+                <strong>Über mich:</strong>
+                <p class="text-muted">{$profile.about_me|default:"Noch nichts eingetragen."}</p>
+
+                <strong>Andere Netzwerke:</strong>
+                <ul class="text-muted list-unstyled">
+                    {if $profile.instagram}<li>📸 <a href="{$profile.instagram}" target="_blank">Instagram</a></li>{/if}
+                    {if $profile.tiktok}<li>🎵 <a href="{$profile.tiktok}" target="_blank">TikTok</a></li>{/if}
+                    {if $profile.discord}<li>💬 {$profile.discord}</li>{/if}
+                    {if $profile.ms_teams}<li>🧑‍💼 {$profile.ms_teams}</li>{/if}
+                </ul>
+            </div>
+        </div>
 
         <section class="text-center">
-            <a href="bearbeiten.php" class="btn btn-primary btn-lg mt-30">Profil bearbeiten</a>
+            <a href="edit_profile.php" class="btn btn-primary btn-lg mt-30">Profil bearbeiten</a>
         </section>
 
         <hr class="my-5">


### PR DESCRIPTION
## Summary
- add DB helpers for profile operations
- load profile data on profile page
- use new dynamic profile template
- provide pages to edit and save profile data

## Testing
- `php -l includes/db.inc.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68472cf39498833298aee3be2cb6c751