### PR TITLE
Integrate lerngruppen functionality

### DIFF
--- a/public/lerngruppen.php
+++ b/public/lerngruppen.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/config.inc.php';
+
+// Zugriffsschutz: nur eingeloggte Nutzer
+if (empty($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+
+$userId  = $_SESSION['user_id'];
+$error   = '';
+$success = '';
+
+// Gruppenaktionen verarbeiten
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['create_group'])) {
+        $groupName = trim($_POST['group_name'] ?? '');
+        if ($groupName === '') {
+            $error = 'Bitte gib einen Gruppennamen ein.';
+        } elseif (DbFunctions::fetchGroupByName($groupName)) {
+            $error = 'Dieser Gruppenname ist bereits vergeben.';
+        } else {
+            $newGroupId = DbFunctions::createGroup($groupName, $userId);
+            if ($newGroupId) {
+                $success = 'Die Gruppe wurde erfolgreich erstellt.';
+            } else {
+                $error = 'Fehler: Gruppe konnte nicht erstellt werden.';
+            }
+        }
+    } elseif (isset($_POST['join_group'])) {
+        $groupName = trim($_POST['group_name'] ?? '');
+        if ($groupName === '') {
+            $error = 'Bitte gib einen Gruppenname ein.';
+        } else {
+            $group = DbFunctions::fetchGroupByName($groupName);
+            if (!$group) {
+                $error = 'Keine Gruppe mit diesem Namen gefunden.';
+            } else {
+                $groupId = (int)$group['id'];
+                if (DbFunctions::addUserToGroup($groupId, $userId)) {
+                    $success = 'Du bist der Gruppe beigetreten.';
+                } else {
+                    $error = 'Fehler: dem Gruppenbeitritt ist fehlgeschlagen.';
+                }
+            }
+        }
+    } elseif (isset($_POST['leave_group'])) {
+        $currentGroup = DbFunctions::fetchGroupByUser($userId);
+        if ($currentGroup && DbFunctions::removeUserFromGroup((int)$currentGroup['id'], $userId)) {
+            $success = 'Du hast die Gruppe verlassen.';
+        } else {
+            $error = 'Fehler: Konnte die Gruppe nicht verlassen.';
+        }
+    }
+}
+
+// Aktuelle Gruppeninfos laden
+$currentGroup = DbFunctions::fetchGroupByUser($userId);
+$members      = [];
+$groupFiles   = [];
+if ($currentGroup) {
+    $groupId    = (int)$currentGroup['id'];
+    $members    = DbFunctions::getGroupMembers($groupId);
+    $groupFiles = DbFunctions::getUploadsByGroup($groupId);
+}
+
+$smarty->assign([
+    'group'         => $currentGroup,
+    'members'       => $members,
+    'group_uploads' => $groupFiles,
+]);
+if ($error !== '') {
+    $smarty->assign('error', $error);
+}
+if ($success !== '') {
+    $smarty->assign('success', $success);
+}
+
+$smarty->display('lerngruppen.tpl');

--- a/templates/lerngruppen.tpl
+++ b/templates/lerngruppen.tpl
@@ -1,0 +1,84 @@
+{extends file="./layouts/layout.tpl"}
+{block name="title"}Meine Lerngruppe{/block}
+
+{block name="content"}
+<div class="container mt-5">
+  {if $group}
+    <h1 class="mb-4 text-center">Meine Lerngruppe: {$group.name|escape}</h1>
+  {else}
+    <h1 class="mb-4 text-center">Meine Lerngruppe</h1>
+  {/if}
+
+  {if isset($error)}
+    <div class="alert alert-danger">{$error}</div>
+  {/if}
+  {if isset($success)}
+    <div class="alert alert-success">{$success}</div>
+  {/if}
+
+  {if $group}
+    <!-- Gruppeninformationen anzeigen -->
+    <div class="text-end mb-3">
+      <form method="post">
+        <button type="submit" name="leave_group" class="btn btn-outline-danger">
+          Gruppe verlassen
+        </button>
+      </form>
+    </div>
+    <h3 class="mb-3">Mitglieder</h3>
+    <div class="table-responsive card shadow-sm mb-4">
+      <table class="table table-striped table-bordered align-middle mb-0">
+        <thead class="table-dark text-center">
+          <tr><th>Username</th><th>E-Mail</th></tr>
+        </thead>
+        <tbody>
+          {foreach $members as $member}
+            <tr>
+              <td>{$member.username|escape}</td>
+              <td>{$member.email|escape}</td>
+            </tr>
+          {/foreach}
+        </tbody>
+      </table>
+    </div>
+    <h3 class="mb-2">Lernmaterialien</h3>
+    {if $group_uploads|@count > 0}
+      <ul class="list-group mb-4">
+        {foreach $group_uploads as $upload}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            {$upload.title|escape}
+            <a href="download.php?id={$upload.id}" class="btn btn-sm btn-outline-primary" download>Herunterladen</a>
+          </li>
+        {/foreach}
+      </ul>
+    {else}
+      <p class="text-muted">Keine Materialien vorhanden.</p>
+    {/if}
+  {else}
+    <!-- Optionen zum Beitreten oder Erstellen einer Gruppe -->
+    <p class="mb-4 text-center">Du bist derzeit in keiner Lerngruppe.</p>
+    <div class="row">
+      <div class="col-md-6">
+        <h3 class="mb-3">Neue Gruppe erstellen</h3>
+        <form method="post" action="{$base_url}/lerngruppen.php">
+          <div class="mb-3">
+            <label for="new_group_name" class="form-label">Gruppenname</label>
+            <input type="text" name="group_name" id="new_group_name" class="form-control" required>
+          </div>
+          <button type="submit" name="create_group" class="btn btn-primary">Erstellen</button>
+        </form>
+      </div>
+      <div class="col-md-6">
+        <h3 class="mb-3">Bestehender Gruppe beitreten</h3>
+        <form method="post" action="{$base_url}/lerngruppen.php">
+          <div class="mb-3">
+            <label for="join_group_name" class="form-label">Gruppenname</label>
+            <input type="text" name="group_name" id="join_group_name" class="form-control" required>
+          </div>
+          <button type="submit" name="join_group" class="btn btn-primary">Beitreten</button>
+        </form>
+      </div>
+    </div>
+  {/if}
+</div>
+{/block}


### PR DESCRIPTION
## Summary
- copy learning group template into the main templates folder
- create `public/lerngruppen.php` page that handles group creation/join/leave
- extend `DbFunctions` with helper methods for learning groups

## Testing
- `php -l public/lerngruppen.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68472cce511883328c052fba47af8dc1