### PR TITLE
Implement password reset workflow

### DIFF
--- a/includes/config.inc.php
+++ b/includes/config.inc.php
@@ -78,6 +78,7 @@ $config['mail'] = [
     'from_name'  => $_ENV['SMTP_FROM_NAME'] ?? 'StudyHub',
     'encryption' => PHPMailer::ENCRYPTION_STARTTLS,
     'verify_subject' => 'Bitte bestätige deine E-Mail-Adresse',
+    'reset_subject'  => 'Passwort zurücksetzen',
     'contact_email' => $_ENV['CONTACT_EMAIL'] ?? ''
 ];
 

--- a/includes/password_reset.inc.php
+++ b/includes/password_reset.inc.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Versendet eine E-Mail zum Zurücksetzen des Passworts.
+ */
+function sendPasswordResetEmail(
+    PDO $pdo,
+    int $userId,
+    string $username,
+    string $email,
+    string $token
+): void {
+    global $config;
+
+    $siteUrl = $config['site_url'] ?? $config['base_url'] ?? '';
+    if (!$siteUrl) {
+        throw new RuntimeException('Keine site_url oder base_url vorhanden.');
+    }
+    $link = rtrim($siteUrl, '/') . '/reset_password.php?token=' . urlencode($token);
+
+    $subject = $config['mail']['reset_subject'] ?? 'Passwort zurücksetzen';
+
+    $htmlBody = "<p>Hallo <strong>{$username}</strong>,</p>
+        <p>klicke auf diesen Link, um dein Passwort zurückzusetzen:</p>
+        <p><a href=\"{$link}\">Passwort jetzt zurücksetzen</a></p>
+        <p>Viele Grüße,<br>StudyHub-Team</p>";
+
+    $altBody = "Hallo {$username},\n\n" .
+        "bitte setze dein Passwort über diesen Link zurück:\n{$link}\n\n" .
+        "Viele Grüße,\nStudyHub-Team";
+
+    sendMail($email, $username, $subject, $htmlBody, $altBody);
+}

--- a/public/request_password_reset.php
+++ b/public/request_password_reset.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+session_start();
+header('Content-Type: text/html; charset=utf-8');
+
+require_once __DIR__ . '/../includes/config.inc.php';
+require_once __DIR__ . '/../src/PasswordController.php';
+
+$log = LoggerFactory::get('request_password_reset');
+$success = false;
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $identifier = trim($_POST['identifier'] ?? '');
+    try {
+        if ($identifier === '') {
+            throw new RuntimeException('Feld leer');
+        }
+        PasswordController::requestReset($identifier);
+        $success = true;
+    } catch (Throwable $e) {
+        $log->error('Passwort-Reset-Anfrage fehlgeschlagen', ['error' => $e->getMessage()]);
+        $message = defined('DEBUG') ? $e->getMessage() : 'Fehler beim Versenden der E-Mail.';
+    }
+}
+
+$smarty->assign('success', $success);
+$smarty->assign('message', $message);
+$smarty->display('request_password_reset.tpl');

--- a/public/reset_password.php
+++ b/public/reset_password.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+session_start();
+header('Content-Type: text/html; charset=utf-8');
+
+require_once __DIR__ . '/../includes/config.inc.php';
+require_once __DIR__ . '/../src/PasswordController.php';
+
+$log   = LoggerFactory::get('reset_password');
+$token = trim($_GET['token'] ?? '');
+$success = false;
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $password = $_POST['password'] ?? '';
+    $confirm  = $_POST['password_confirm'] ?? '';
+    try {
+        if ($token === '' || $password === '' || $confirm === '') {
+            throw new RuntimeException('Fehlende Eingaben');
+        }
+        if ($password !== $confirm) {
+            throw new RuntimeException('Passwörter stimmen nicht überein');
+        }
+        PasswordController::resetPassword($token, $password);
+        $success = true;
+    } catch (Throwable $e) {
+        $log->error('Passwort zurücksetzen fehlgeschlagen', ['error' => $e->getMessage()]);
+        $message = defined('DEBUG') ? $e->getMessage() : 'Fehler beim Zurücksetzen des Passworts.';
+    }
+}
+
+$smarty->assign('token', $token);
+$smarty->assign('success', $success);
+$smarty->assign('message', $message);
+$smarty->display('reset_password.tpl');

--- a/sql/create_password_reset_tokens_table.sql
+++ b/sql/create_password_reset_tokens_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE password_reset_tokens (
+    user_id INT NOT NULL,
+    reset_token VARCHAR(64) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    PRIMARY KEY (user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX (reset_token)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/PasswordController.php
+++ b/src/PasswordController.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/../includes/config.inc.php';
+require_once __DIR__ . '/../includes/password_reset.inc.php';
+
+class PasswordController
+{
+    public static function requestReset(string $identifier): void
+    {
+        $user = DbFunctions::fetchUserByIdentifier($identifier);
+        if (!$user) {
+            throw new RuntimeException('Benutzer nicht gefunden');
+        }
+
+        $token = bin2hex(random_bytes(32));
+        DbFunctions::storePasswordResetToken((int)$user['id'], $token);
+        sendPasswordResetEmail(DbFunctions::db_connect(), (int)$user['id'], $user['username'], $user['email'], $token);
+    }
+
+    public static function resetPassword(string $token, string $password): void
+    {
+        $user = DbFunctions::fetchPasswordResetUser($token);
+        if (!$user) {
+            throw new RuntimeException('Token ungültig oder abgelaufen');
+        }
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        DbFunctions::updatePassword((int)$user['id'], $hash);
+        DbFunctions::deletePasswordResetToken((int)$user['id']);
+    }
+
+    public static function changePassword(int $userId, string $oldPassword, string $newPassword): void
+    {
+        $user = DbFunctions::fetchUserById($userId);
+        if (!$user || !verifyPassword($oldPassword, $user['password_hash'])) {
+            throw new RuntimeException('Aktuelles Passwort falsch');
+        }
+        $hash = password_hash($newPassword, PASSWORD_DEFAULT);
+        DbFunctions::updatePassword($userId, $hash);
+    }
+}

--- a/templates/partials/modals.tpl
+++ b/templates/partials/modals.tpl
@@ -33,6 +33,9 @@
             <span id="login-spinner" class="spinner-border spinner-border-sm me-2 d-none" role="status"></span>
             Login
           </button>
+          <div class="mt-2 text-end">
+            <a href="request_password_reset.php">Passwort vergessen?</a>
+          </div>
         </form>
       </div>
     </div>

--- a/templates/request_password_reset.tpl
+++ b/templates/request_password_reset.tpl
@@ -1,0 +1,19 @@
+{extends file="./layouts/layout.tpl"}
+
+{block name="title"}Passwort vergessen{/block}
+
+{block name="content"}
+<h1>Passwort zurücksetzen</h1>
+{if $success}
+    <div class="alert alert-success">E-Mail wurde versendet.</div>
+{elseif $message}
+    <div class="alert alert-danger">{$message}</div>
+{/if}
+<form method="post" class="needs-validation" novalidate>
+    <div class="mb-3">
+        <label for="identifier" class="form-label">Benutzername oder E-Mail</label>
+        <input type="text" class="form-control" id="identifier" name="identifier" required>
+    </div>
+    <button type="submit" class="btn btn-primary">E-Mail senden</button>
+</form>
+{/block}

--- a/templates/reset_password.tpl
+++ b/templates/reset_password.tpl
@@ -1,0 +1,25 @@
+{extends file="./layouts/layout.tpl"}
+
+{block name="title"}Passwort zurücksetzen{/block}
+
+{block name="content"}
+<h1>Neues Passwort setzen</h1>
+{if $success}
+    <div class="alert alert-success">Passwort wurde geändert.</div>
+{elseif $message}
+    <div class="alert alert-danger">{$message}</div>
+{/if}
+{if !$success}
+<form method="post" class="needs-validation" novalidate>
+    <div class="mb-3">
+        <label for="password" class="form-label">Neues Passwort</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+    </div>
+    <div class="mb-3">
+        <label for="password_confirm" class="form-label">Passwort bestätigen</label>
+        <input type="password" class="form-control" id="password_confirm" name="password_confirm" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Passwort speichern</button>
+</form>
+{/if}
+{/block}


### PR DESCRIPTION
## Summary
- add email helper and DB helpers for password reset tokens
- implement `PasswordController` and public pages for requesting and performing resets
- show "Passwort vergessen?" link in the login modal
- remove password change handling from profile page
- new SQL migration for `password_reset_tokens`

## Testing
- `php -l public/profile.php` *(fails: `php: command not found`)*
- `php -l templates/profile.tpl` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68432996dc88833283d68902f1617d68