### PR TITLE
Integrate todos page

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -340,11 +340,53 @@ class DbFunctions
     public static function disableTwoFA(string $username): void
     {
         $sql = '
-            UPDATE users 
+            UPDATE users
             SET twofa_secret = NULL, is_twofa_enabled = 0
             WHERE username = :username
         ';
         self::execute($sql, [':username' => $username]);
+    }
+
+    // Holt alle ToDos für den angegebenen Benutzer
+    public static function getTodosByUserId(int $userId): array
+    {
+        $query = '
+        SELECT * FROM todos
+        WHERE user_id = ?
+        ORDER BY created_at DESC
+    ';
+        return self::execute($query, [$userId], true);
+    }
+
+    // Fügt ein neues ToDo ein
+    public static function insertTodo(int $userId, string $text, ?string $dueDate): void
+    {
+        $query = '
+        INSERT INTO todos (user_id, text, due_date)
+        VALUES (?, ?, ?)
+    ';
+        self::execute($query, [$userId, $text, $dueDate]);
+    }
+
+    // Holt den aktuellen Status eines ToDos
+    public static function getTodoStatus(int $todoId, int $userId): ?array
+    {
+        $query = '
+        SELECT is_done FROM todos
+        WHERE id = ? AND user_id = ?
+    ';
+        return self::execute($query, [$todoId, $userId], false);
+    }
+
+    // Aktualisiert den Status eines ToDos
+    public static function updateTodoStatus(int $todoId, int $userId, int $newStatus): void
+    {
+        $query = '
+        UPDATE todos
+        SET is_done = ?
+        WHERE id = ? AND user_id = ?
+    ';
+        self::execute($query, [$newStatus, $todoId, $userId]);
     }
 }
 

--- a/public/todos.php
+++ b/public/todos.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+require_once __DIR__ . '/../includes/config.inc.php';
+
+// Initialisiere die Session-Variable für kürzlich erledigte Aufgaben
+if (!isset($_SESSION['just_completed'])) {
+    $_SESSION['just_completed'] = [];
+}
+
+// Sicherstellen, dass der Benutzer eingeloggt ist
+if (empty($_SESSION['user_id'])) {
+    $reason = urlencode("Du musst eingeloggt sein, um ToDos zu erstellen.");
+    header("Location: /studyhub/error/403?reason={$reason}&action=both");
+    exit;
+}
+
+$pdo = DbFunctions::db_connect();
+$userId = (int)$_SESSION['user_id'];
+$showDone = isset($_GET['show_done']) && $_GET['show_done'] == '1';
+
+// Neues ToDo hinzufügen, inklusive Fälligkeitsdatum
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['new_todo'])) {
+    $text = trim($_POST['new_todo']);
+    $dueDate = !empty($_POST['due_date']) ? $_POST['due_date'] : null;
+
+    if ($text !== '') {
+        DbFunctions::insertTodo($userId, $text, $dueDate); 
+    }
+
+    // Nach dem Hinzufügen neu laden (Vermeidung von POST-Resubmits)
+    header("Location: todos.php");
+    exit;
+}
+
+// ToDo als erledigt oder rückgängig markieren
+if (isset($_GET['toggle'])) {
+    $todoId = (int)$_GET['toggle'];
+    
+    $todo = DbFunctions::getTodoStatus($todoId, $userId);
+    
+    if ($todo) {
+        $newStatus = (int)!$todo['is_done'];
+        DbFunctions::updateTodoStatus($todoId, $userId, $newStatus);
+        
+        if ($newStatus === 1) {
+            $_SESSION['just_completed'][] = $todoId;
+        } else {
+            $_SESSION['just_completed'] = array_diff($_SESSION['just_completed'], [$todoId]);
+        }
+    }
+    
+    header("Location: todos.php");
+    exit;
+}
+
+
+// Alle ToDos des Benutzers laden (auch die bereits erledigten)
+$todos = DbFunctions::getTodosByUserId($userId);
+
+// ToDos in offene und erledigte Aufgaben aufteilen
+$todos_unfinished = [];
+$todos_finished = [];
+
+foreach ($todos as $todo) {
+    if ($todo['is_done']) {
+        $todos_finished[] = $todo;
+    } else {
+        $todos_unfinished[] = $todo;
+    }
+}
+
+// Für UI-Highlight von neu erledigten Aufgaben
+$justCompleted = $_SESSION['just_completed'] ?? [];
+
+// Heutiges Datum (für Prüfung auf Überfälligkeit im Template)
+$today = date('Y-m-d');
+$smarty->assign('today', $today);
+
+// Daten an Smarty-Template übergeben
+$smarty->assign('justCompleted', $justCompleted);
+$smarty->assign('todos_unfinished', $todos_unfinished);
+$smarty->assign('todos_finished', $todos_finished);
+$smarty->assign('showDone', $showDone);
+
+// Session zurücksetzen, damit Hervorhebung beim nächsten Laden nicht bleibt
+unset($_SESSION['just_completed']);
+
+// Template rendern
+$smarty->display('todos.tpl');

--- a/templates/todos.tpl
+++ b/templates/todos.tpl
@@ -1,0 +1,97 @@
+{extends file="./layouts/layout.tpl"}
+
+{block name="title"}Meine ToDo-Liste{/block}
+
+{block name="content"}
+<div class="container my-5">
+    <h1 class="mb-4">Meine ToDo-Liste</h1>
+
+    {*Formular zum Hinzufügen eines neuen ToDos.
+        Optional kann ein Fälligkeitsdatum mitgegeben werden.*}
+    <form method="post" class="mb-4">
+        <div class="row g-2">
+            <div class="col-md-8">
+                <input type="text" name="new_todo" class="form-control" placeholder="Neues ToDo..." required>
+            </div>
+            <div class="col-md-3">
+                <input type="date" name="due_date" class="form-control" placeholder="Fälligkeitsdatum">
+            </div>
+            <div class="col-md-1">
+                <button type="submit" class="btn btn-primary w-100">+</button>
+            </div>
+        </div>
+    </form>
+
+ 
+    <h2>Offene Aufgaben</h2>
+    {if $todos_unfinished|@count > 0}
+        <ul class="list-group mb-5">
+            {foreach $todos_unfinished as $todo}
+                {assign var="isOverdue" value=($todo.due_date && $todo.due_date < $today)}
+                <li class="list-group-item d-flex justify-content-between align-items-center {if $isOverdue}bg-danger bg-opacity-10{/if}">
+
+                    <div>
+                        <strong>{$todo.text|escape}</strong>
+                        {if $todo.due_date}
+                            <div class="text-muted small">
+                                Fällig: {$todo.due_date|date_format:"%d.%m.%Y"}
+                            </div>
+                        {/if}
+                    </div>
+
+                    {* Link zum Togglen des Status (erledigt) *}
+                    <a href="?toggle={$todo.id}&show_done={$showDone ? 1 : 0}" class="btn btn-sm btn-outline-success">
+                        Erledigt
+                    </a>
+                </li>
+            {/foreach}
+        </ul>
+    {else}
+        <p>Keine offenen Aufgaben.</p>
+    {/if}
+
+   
+    <h2>Erledigte Aufgaben</h2>
+
+    {* Umschaltknopf für Sichtbarkeit erledigter Aufgaben *}
+    <form method="get" class="mb-3">
+        <input type="hidden" name="show_done" value="{if $showDone}0{else}1{/if}">
+        <button type="submit" class="btn btn-secondary">
+            {if $showDone}
+                Erledigte ausblenden
+            {else}
+                Alle erledigten anzeigen
+            {/if}
+        </button>
+    </form>
+
+    {if $showDone}
+        {if $todos_finished|@count > 0}
+            <ul class="list-group">
+                {foreach $todos_finished as $todo}
+                    <li class="list-group-item d-flex justify-content-between align-items-center list-group-item-success">
+
+                        <div>
+                            <span class="text-decoration-line-through">{$todo.text|escape}</span>
+                            {if $todo.due_date}
+                                <div class="text-muted small">
+                                    Fällig: {$todo.due_date|date_format:"%d.%m.%Y"}
+                                </div>
+                            {/if}
+                        </div>
+
+                        {* Rückgängig-Link (erneutes Togglen auf "nicht erledigt") *}
+                        <a href="?toggle={$todo.id}&show_done=1" class="btn btn-sm btn-outline-danger">
+                            Rückgängig
+                        </a>
+                    </li>
+                {/foreach}
+            </ul>
+        {else}
+            <p>Keine erledigten Aufgaben.</p>
+        {/if}
+    {else}
+        <p class="text-muted">Erledigte Aufgaben werden derzeit ausgeblendet.</p>
+    {/if}
+</div>
+{/block}


### PR DESCRIPTION
## Summary
- add new todos page for public section
- include todos template in main templates directory
- extend database layer with todo functions

## Testing
- `php -l public/todos.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684842f2cc7c83328ad13ade7282b84c