### PR TITLE
Implement central PDF conversion

### DIFF
--- a/includes/config.inc.php
+++ b/includes/config.inc.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../includes/mailing.inc.php';
 require_once __DIR__ . '/../includes/central_logs.inc.php';
 require_once __DIR__ . '/../includes/crypto.inc.php';
 require_once __DIR__ . '/../includes/logger.inc.php';
+require_once __DIR__ . '/../includes/converter.inc.php';
 require_once __DIR__ . '/../src/ILogger.php';
 require_once __DIR__ . '/../src/MonologLoggerAdapter.php';
 require_once __DIR__ . '/../src/LoggerFactory.php';

--- a/includes/converter.inc.php
+++ b/includes/converter.inc.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Konvertiert eine Datei mit LibreOffice in ein PDF.
+ * Gibt den Pfad zur PDF-Datei oder null bei Fehler zurück.
+ */
+function convertToPdf(string $filePath): ?string
+{
+    $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+    if ($ext === 'pdf') {
+        return $filePath; // bereits PDF
+    }
+
+    $outputDir = dirname($filePath);
+    $escapedInput = escapeshellarg($filePath);
+    $escapedDir = escapeshellarg($outputDir);
+
+    $cmd = "libreoffice --headless --convert-to pdf --outdir $escapedDir $escapedInput";
+    exec($cmd . ' 2>&1', $out, $ret);
+
+    if ($ret === 0) {
+        $pdfPath = $outputDir . '/' . basename($filePath, '.' . $ext) . '.pdf';
+        if (file_exists($pdfPath)) {
+            return $pdfPath;
+        }
+    }
+    return null;
+}
+
+/**
+ * Konvertiert hochgeladene Dateien (außer PPT/PPTX) automatisch nach PDF.
+ * Gibt den neuen Dateinamen zurück, wenn konvertiert wurde.
+ */
+function handleUploadConversion(string $filePath, bool $force = false): string
+{
+    $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+
+    // PPT und PPTX nur auf Wunsch konvertieren
+    if (!$force && in_array($ext, ['ppt', 'pptx'], true)) {
+        return basename($filePath);
+    }
+
+    $pdf = convertToPdf($filePath);
+    if ($pdf) {
+        // Original entfernen und neuen Namen zurückgeben
+        if ($pdf !== $filePath) {
+            @unlink($filePath);
+        }
+        return basename($pdf);
+    }
+
+    return basename($filePath);
+}

--- a/public/upload.php
+++ b/public/upload.php
@@ -102,6 +102,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $destination = $uploadDir . $storedName;
 
                     if (move_uploaded_file($file['tmp_name'], $destination)) {
+                        $force = isset($_POST['convert_ppt']) && $_POST['convert_ppt'] === '1';
+                        $newName = handleUploadConversion($destination, $force);
+                        if ($newName !== basename($destination)) {
+                            $storedName = $newName;
+                            $destination = $uploadDir . $storedName;
+                        }
                         try {
                             if ($course === '__custom__') {
                                 DbFunctions::submitCourseSuggestion($customCourse, (int)$_SESSION['user_id']);

--- a/public/upload.php
+++ b/public/upload.php
@@ -140,7 +140,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         }
                     } else {
                         $error = 'Konnte Datei nicht speichern.';
-                        $log->error('Datei konnte nicht gespeichert werden', ['user_id' => $_SESSION['user_id']]);
+                        $log->error('Datei konnte nicht gespeichert werden', [
+                            'user_id' => $_SESSION['user_id'],
+                            'tmp_name' => $file['tmp_name'],
+                            'destination' => $destination,
+                            'move_error' => error_get_last()
+                        ]);
                     }
                 }
             }

--- a/templates/upload.tpl
+++ b/templates/upload.tpl
@@ -52,8 +52,8 @@
 
         <div class="mb-3">
             <label for="file" class="form-label">Datei auswählen</label>
-            <input type="file" id="file" name="file" class="form-control" accept=".pdf,.jpg,.jpeg,.png,.txt" required>
-            <div class="form-text">Erlaubte Dateitypen: PDF, JPG, PNG, TXT, DOC, DOCX, ODT, PPT Max. 10 MB.</div>
+            <input type="file" id="file" name="file" class="form-control" accept=".pdf,.jpg,.jpeg,.png,.txt,.doc,.docx,.odt,.ppt,.pptx" required>
+            <div class="form-text">Erlaubte Dateitypen: PDF, JPG, PNG, TXT, DOC, DOCX, ODT, PPT, PPTX. Max. 10 MB.</div>
         </div>
 
         <div class="mb-3" id="ppt-convert-wrapper" style="display:none;">

--- a/templates/upload.tpl
+++ b/templates/upload.tpl
@@ -56,6 +56,14 @@
             <div class="form-text">Erlaubte Dateitypen: PDF, JPG, PNG, TXT, DOC, DOCX, ODT, PPT Max. 10 MB.</div>
         </div>
 
+        <div class="mb-3" id="ppt-convert-wrapper" style="display:none;">
+            <label for="convert_ppt" class="form-label">PowerPoint in PDF umwandeln?</label>
+            <select id="convert_ppt" name="convert_ppt" class="form-select">
+                <option value="1" selected>Ja</option>
+                <option value="0">Nein</option>
+            </select>
+        </div>
+
         <button type="submit" class="btn btn-primary">Hochladen</button>
     </form>
 
@@ -81,6 +89,10 @@ function toggleCustomCourse(value) {
 document.addEventListener('DOMContentLoaded', function () {
     toggleCustomCourse(document.getElementById('course').value);
     toggleAction(document.getElementById('action').value);
+    checkPpt(document.getElementById('file').value);
+    document.getElementById('file').addEventListener('change', function(){
+        checkPpt(this.value);
+    });
 });
 
 function toggleAction(val) {
@@ -93,6 +105,13 @@ function toggleAction(val) {
         uploadForm.style.display = 'block';
         suggestForm.style.display = 'none';
     }
+}
+
+function checkPpt(filename) {
+    const wrapper = document.getElementById('ppt-convert-wrapper');
+    const lower = filename.toLowerCase();
+    const show = lower.endsWith('.ppt') || lower.endsWith('.pptx');
+    wrapper.style.display = show ? 'block' : 'none';
 }
 </script>
 {/literal}


### PR DESCRIPTION
## Summary
- add converter helper to convert files via LibreOffice
- load converter in config
- convert uploads automatically except for PPT
- allow user choice to convert PPT files in upload form

## Testing
- `php -l includes/converter.inc.php` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684865f4d1248332bde9ae732522bf37