### PR TITLE
Prevent unapproved materials from appearing

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -230,14 +230,20 @@ class DbFunctions
     /** Material abruf für "Material finden/suchen" **/
     public static function getAllMaterials(): array
     {
-        $query = 'SELECT id, title, description FROM materials';
-        return self::execute($query, [], true); // true → fetchAll() wird ausgeführt
+        $query = 'SELECT DISTINCT m.id, m.title, m.description
+                  FROM materials m
+                  JOIN uploads u ON u.material_id = m.id
+                  WHERE u.is_approved = 1';
+        return self::execute($query, [], true);
     }
 
     public static function getMaterialsByTitle(string $searchTerm): array
     {
         $pdo = self::db_connect();
-        $stmt = $pdo->prepare('SELECT * FROM materials WHERE title LIKE :search');
+        $stmt = $pdo->prepare('SELECT DISTINCT m.*
+            FROM materials m
+            JOIN uploads u ON u.material_id = m.id
+            WHERE u.is_approved = 1 AND m.title LIKE :search');
         $stmt->execute(['search' => '%' . $searchTerm . '%']);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }

--- a/public/upload.php
+++ b/public/upload.php
@@ -101,6 +101,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     'material_id' => $materialId
                                 ]);
 
+                                // Material erscheint erst nach Freigabe in den Listen
                                 $success = 'Datei erfolgreich hochgeladen und wartet auf Freigabe.';
                             }
 


### PR DESCRIPTION
## Summary
- only list materials that have at least one approved upload
- clarify comment in upload screen about file visibility

## Testing
- `php -l includes/db.inc.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685155ed9ba08332968cfd9d837e5657