### PR TITLE
Fix group membership handling

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -56,6 +56,11 @@ class DbFunctions
             $stmt = $pdo->prepare('INSERT INTO group_members (group_id, user_id) VALUES (:gid, :uid)');
             $stmt->execute([':gid' => $groupId, ':uid' => $userId]);
 
+            $stmt = $pdo->prepare(
+                'INSERT INTO group_roles (group_id, user_id, role) VALUES (:gid, :uid, :role)'
+            );
+            $stmt->execute([':gid' => $groupId, ':uid' => $userId, ':role' => 'admin']);
+
             $pdo->commit();
             return $groupId;
         } catch (Exception $e) {
@@ -85,6 +90,12 @@ class DbFunctions
     // Entfernt einen Benutzer aus einer Gruppe
     public static function removeUserFromGroup(int $groupId, int $userId): bool
     {
+        // Rolle entfernen
+        self::execute(
+            'DELETE FROM group_roles WHERE group_id = :gid AND user_id = :uid',
+            [':gid' => $groupId, ':uid' => $userId]
+        );
+
         $sql = '
         DELETE FROM group_members
         WHERE group_id = :gid AND user_id = :uid

--- a/public/groups.php
+++ b/public/groups.php
@@ -47,6 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['join_group'])) {
         } else {
             $id = (int)$group['id'];
             if (DbFunctions::addUserToGroup($id, $userId)) {
+                DbFunctions::setUserRoleInGroup($id, $userId, 'member');
                 header("Location: /studyhub/gruppe.php?id={$id}");
                 exit;
             } else {


### PR DESCRIPTION
## Summary
- keep roles synced when groups are created, joined or left
- remove stale roles when a user leaves a group
- assign `member` role when joining via `groups.php`

## Testing
- `php -l includes/db.inc.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685184e548b48332a9fb04ea7cddedda