### PR TITLE
Add group upload option

### DIFF
--- a/public/gruppe.php
+++ b/public/gruppe.php
@@ -62,7 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     // Upload-Link
     elseif (isset($_POST['upload_group']) && $myRole !== 'none') {
-        header("Location: upload.php?group_id={$groupId}");
+        header('Location: upload.php?action=group_upload');
         exit;
     }
 }

--- a/templates/upload.tpl
+++ b/templates/upload.tpl
@@ -16,13 +16,19 @@
         <label for="action" class="form-label">Aktion wählen</label>
         <select id="action" name="action" class="form-select" onchange="toggleAction(this.value)">
             <option value="upload" {if $action == 'upload'}selected{/if}>Material hochladen</option>
+            {if $userGroup}
+            <option value="group_upload" {if $action == 'group_upload'}selected{/if}>Eine Lerngruppe hochladen</option>
+            {/if}
             <option value="suggest" {if $action == 'suggest'}selected{/if}>Kurs vorschlagen</option>
         </select>
     </div>
 
     <form id="upload-form" action="{$base_url}/upload.php" method="post" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{$csrf_token}">
-        <input type="hidden" name="action" value="upload">
+        <input type="hidden" name="action" value="{$action}">
+        {if $action == 'group_upload'}
+        <input type="hidden" name="group_upload" value="1">
+        {/if}
 
         <div class="mb-3">
             <label for="title" class="form-label">Titel</label>
@@ -49,8 +55,8 @@
             <input type="text" id="custom_course" name="custom_course" class="form-control" value="{$customCourse|escape}" placeholder="z. B. Informatik 1">
         </div>
 
-        {if $userGroup}
-        <div class="mb-3 form-check">
+        {if $userGroup && $action != 'group_upload'}
+        <div class="mb-3 form-check" id="group-upload-wrapper">
             <input class="form-check-input" type="checkbox" id="group_upload" name="group_upload" value="1" {if $groupUploadChecked}checked{/if}>
             <label class="form-check-label" for="group_upload">Für meine Lerngruppe hochladen</label>
         </div>
@@ -92,12 +98,16 @@ document.addEventListener('DOMContentLoaded', function () {
 function toggleAction(val) {
     const uploadForm = document.getElementById('upload-form');
     const suggestForm = document.getElementById('suggest-form');
+    const groupWrapper = document.getElementById('group-upload-wrapper');
     if (val === 'suggest') {
         uploadForm.style.display = 'none';
         suggestForm.style.display = 'block';
     } else {
         uploadForm.style.display = 'block';
         suggestForm.style.display = 'none';
+    }
+    if (groupWrapper) {
+        groupWrapper.style.display = (val === 'upload') ? 'block' : 'none';
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- enable a `group_upload` action in public upload logic
- add "Eine Lerngruppe hochladen" option to upload UI
- auto-select group upload when opening from group page

## Testing
- `php -l public/upload.php` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c1fa8cb8833283fd2179ffc8ae6e