### PR TITLE
Allow selecting study group for uploads

### DIFF
--- a/includes/pdf_utils.inc.php
+++ b/includes/pdf_utils.inc.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use TCPDF;
+//use TCPDF;
 
 /**
  * Konvertiert eine Datei mit TCPDF nach PDF.

--- a/public/upload.php
+++ b/public/upload.php
@@ -22,8 +22,22 @@ $action = $_POST['action'] ?? ($_GET['action'] ?? 'upload');
 $action = $action === 'suggest' ? 'suggest' : 'upload';
 
 $courses = DbFunctions::getAllCourses();
-$userGroup = DbFunctions::fetchGroupByUser((int)$_SESSION['user_id']);
+$userGroups = DbFunctions::fetchGroupsByUser((int)$_SESSION['user_id']);
 $groupUpload = false;
+$selectedGroupId = 0;
+$uploadTarget = 'public';
+
+if (isset($_GET['group_id'])) {
+    $gid = (int)$_GET['group_id'];
+    foreach ($userGroups as $g) {
+        if ((int)$g['id'] === $gid) {
+            $selectedGroupId = $gid;
+            $groupUpload = true;
+            $uploadTarget = 'group';
+            break;
+        }
+    }
+}
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], (string)$_POST['csrf_token'])) {
@@ -54,9 +68,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $description   = trim($_POST['description'] ?? '');
         $course        = trim($_POST['course'] ?? '');
         $customCourse  = trim($_POST['custom_course'] ?? '');
-        $groupUpload   = isset($_POST['group_upload']) && $userGroup;
+
+        $uploadTarget  = $_POST['upload_target'] ?? 'public';
+        if ($uploadTarget === 'group') {
+            $selectedGroupId = (int)($_POST['group_id'] ?? 0);
+            $ids = array_column($userGroups, 'id');
+            if (in_array($selectedGroupId, $ids, true)) {
+                $groupUpload = true;
+            } else {
+                $selectedGroupId = 0;
+                $groupUpload = false;
+            }
+        }
 
         $smarty->assign('customCourse', $customCourse);
+        $smarty->assign('uploadTarget', $uploadTarget);
 
         if ($title === '' || !isset($_FILES['file'])) {
             $error = 'Titel und Datei sind erforderlich.';
@@ -124,10 +150,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                         $storedName,
                                         $materialId,
                                         (int)$_SESSION['user_id'],
-                                        (int)$userGroup['id'],
+                                        $selectedGroupId,
                                         true
                                     );
-                                    $success = 'Datei erfolgreich für deine Lerngruppe hochgeladen.';
+                                    $success = 'Datei erfolgreich für die Lerngruppe hochgeladen.';
                                 } else {
                                     $uploadId = DbFunctions::uploadFile($storedName, $materialId, (int)$_SESSION['user_id']);
                                     $success  = 'Datei erfolgreich hochgeladen und wartet auf Freigabe.';
@@ -140,7 +166,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     'upload_id'   => $uploadId,
                                     'stored_name' => $storedName,
                                     'material_id' => $materialId,
-                                    'group_id'    => $groupUpload ? $userGroup['id'] : null
+                                    'group_id'    => $groupUpload ? $selectedGroupId : null
                                 ]);
                             }
 
@@ -165,8 +191,9 @@ $smarty->assign([
     'isLoggedIn'          => isset($_SESSION['user_id']),
     'username'            => $_SESSION['username'] ?? null,
     'courses'             => $courses,
-    'userGroup'           => $userGroup,
-    'groupUploadChecked'  => $_POST['group_upload'] ?? false,
+    'userGroups'          => $userGroups,
+    'selectedGroupId'     => $selectedGroupId,
+    'uploadTarget'        => $uploadTarget,
     'selectedCourse'      => $_POST['course'] ?? '',
     'title'               => $_POST['title'] ?? '',
     'description'         => $_POST['description'] ?? '',

--- a/templates/upload.tpl
+++ b/templates/upload.tpl
@@ -49,10 +49,21 @@
             <input type="text" id="custom_course" name="custom_course" class="form-control" value="{$customCourse|escape}" placeholder="z. B. Informatik 1">
         </div>
 
-        {if $userGroup}
-        <div class="mb-3 form-check">
-            <input class="form-check-input" type="checkbox" id="group_upload" name="group_upload" value="1" {if $groupUploadChecked}checked{/if}>
-            <label class="form-check-label" for="group_upload">Für meine Lerngruppe hochladen</label>
+        {if $userGroups|@count > 0}
+        <div class="mb-3">
+            <label for="upload_target" class="form-label">Upload-Ziel</label>
+            <select id="upload_target" name="upload_target" class="form-select" onchange="toggleGroupSelect(this.value)">
+                <option value="public" {if $uploadTarget != 'group'}selected{/if}>Normal hochladen</option>
+                <option value="group" {if $uploadTarget == 'group'}selected{/if}>Eine Lerngruppe hochladen</option>
+            </select>
+        </div>
+        <div class="mb-3" id="group-select" style="display:none;">
+            <label for="group_id" class="form-label">Lerngruppe</label>
+            <select id="group_id" name="group_id" class="form-select">
+                {foreach from=$userGroups item=g}
+                    <option value="{$g.id}" {if $selectedGroupId == $g.id}selected{/if}>{$g.name|escape}</option>
+                {/foreach}
+            </select>
         </div>
         {/if}
 
@@ -87,6 +98,10 @@ function toggleCustomCourse(value) {
 document.addEventListener('DOMContentLoaded', function () {
     toggleCustomCourse(document.getElementById('course').value);
     toggleAction(document.getElementById('action').value);
+    const tgt = document.getElementById('upload_target');
+    if (tgt) {
+        toggleGroupSelect(tgt.value);
+    }
 });
 
 function toggleAction(val) {
@@ -98,6 +113,13 @@ function toggleAction(val) {
     } else {
         uploadForm.style.display = 'block';
         suggestForm.style.display = 'none';
+    }
+}
+
+function toggleGroupSelect(val) {
+    const wrapper = document.getElementById('group-select');
+    if (wrapper) {
+        wrapper.style.display = (val === 'group') ? 'block' : 'none';
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- add ability to choose a study group when uploading
- list user's groups in the upload form
- auto approve uploads sent to groups

## Testing
- `php -l public/upload.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c451899483329639b5f686beddc1