### PR TITLE
Implement learn timer on dashboard

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,0 +1,91 @@
+// dashboard.js
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Collapse icon toggles
+  document.querySelectorAll('.toggle-collapse-icon').forEach(btn => {
+    const icon = btn.querySelector('.collapse-icon');
+    const target = document.querySelector(btn.dataset.bsTarget);
+    if (!target || !icon) return;
+
+    const updateIcon = (expanded) => {
+      icon.textContent = expanded ? 'expand_less' : 'expand_more';
+    };
+
+    updateIcon(target.classList.contains('show'));
+
+    target.addEventListener('show.bs.collapse', () => updateIcon(true));
+    target.addEventListener('hide.bs.collapse', () => updateIcon(false));
+  });
+
+  // Lern-Timer
+  const durationInput = document.getElementById('timerDuration');
+  const startBtn = document.getElementById('startTimerBtn');
+  const modalEl = document.getElementById('timerModal');
+  const timerDisplay = document.getElementById('timerDisplay');
+  const timerMessage = document.getElementById('timerMessage');
+  const closeBtn = document.getElementById('closeTimerBtn');
+
+  if (!durationInput || !startBtn || !modalEl) {
+    return;
+  }
+
+  const modal = new bootstrap.Modal(modalEl);
+  const alarmSound = new Audio(baseUrl + '/assets/alarm.mp3');
+  let countdown;
+  let remaining = 0;
+  let timerRunning = false;
+
+  startBtn.addEventListener('click', () => {
+    const minutes = parseInt(durationInput.value, 10);
+    remaining = (!isNaN(minutes) && minutes > 0 ? minutes : 30) * 60;
+    timerDisplay.textContent = formatTime(remaining);
+    timerMessage.textContent = '';
+    closeBtn.classList.add('d-none');
+    modal.show();
+    timerRunning = true;
+
+    clearInterval(countdown);
+    countdown = setInterval(() => {
+      remaining--;
+      if (remaining <= 0) {
+        clearInterval(countdown);
+        timerDisplay.textContent = formatTime(0);
+        timerMessage.textContent = 'Zeit f\u00fcr eine Pause';
+        closeBtn.classList.remove('d-none');
+        alarmSound.play().catch(() => {});
+        timerRunning = false;
+      } else {
+        timerDisplay.textContent = formatTime(remaining);
+      }
+    }, 1000);
+  });
+
+  modalEl.addEventListener('hide.bs.modal', (e) => {
+    if (timerRunning && remaining > 0) {
+      if (!confirm('Willst du den Timer wirklich abbrechen?')) {
+        e.preventDefault();
+        return;
+      }
+      clearInterval(countdown);
+    }
+    reset();
+  });
+
+  function reset() {
+    timerRunning = false;
+    remaining = 0;
+    durationInput.value = 30;
+    timerMessage.textContent = '';
+  }
+
+  function formatTime(totalSeconds) {
+    const h = Math.floor(totalSeconds / 3600);
+    const m = Math.floor((totalSeconds % 3600) / 60);
+    const s = totalSeconds % 60;
+    const parts = [];
+    if (h > 0) parts.push(String(h).padStart(2, '0'));
+    parts.push(String(m).padStart(2, '0'));
+    parts.push(String(s).padStart(2, '0'));
+    return parts.join(':');
+  }
+});

--- a/templates/dashboard.tpl
+++ b/templates/dashboard.tpl
@@ -5,7 +5,7 @@
 {block name="content"}
 <div class="container mt-5">
   <h1>
-    Hallo, {$username}!<br>
+    Hallo, {$username|escape}!<br>
     <small class="text-muted">
         Rolle:
         {if $isAdmin}
@@ -17,6 +17,21 @@
         {/if}
     </small>
   </h1>
+
+  <section class="my-4" id="learn-timer-section">
+    <h2 class="h4 mb-3">Lerntimer</h2>
+    <div class="row g-2 align-items-center">
+      <div class="col-auto">
+        <label for="timerDuration" class="col-form-label">Dauer (Minuten)</label>
+      </div>
+      <div class="col-auto">
+        <input type="number" class="form-control" id="timerDuration" min="1" value="30">
+      </div>
+      <div class="col-auto">
+        <button type="button" class="btn btn-primary" id="startTimerBtn">Start</button>
+      </div>
+    </div>
+  </section>
 
   {if $isAdmin}
     {* Abschnitt 1 : locked User *}
@@ -315,25 +330,27 @@
   </section>
   {/if}
 </div>
+
+<!-- Lerntimer Modal -->
+<div class="modal fade" id="timerModal" tabindex="-1" aria-labelledby="timerModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content text-center">
+      <div class="modal-header">
+        <h5 class="modal-title" id="timerModalLabel">Lerntimer</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
+      </div>
+      <div class="modal-body">
+        <div id="timerDisplay" class="display-1 fw-bold">00:00</div>
+        <p id="timerMessage" class="h4 mt-3"></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary d-none" id="closeTimerBtn" data-bs-dismiss="modal">Beenden</button>
+      </div>
+    </div>
+  </div>
+</div>
 {/block}
 
 {block name="scripts"}
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    document.querySelectorAll('.toggle-collapse-icon').forEach(btn => {
-      const icon = btn.querySelector('.collapse-icon');
-      const target = document.querySelector(btn.dataset.bsTarget);
-      if (!target || !icon) return;
-
-      const updateIcon = (expanded) => {
-        icon.textContent = expanded ? 'expand_less' : 'expand_more';
-      };
-
-      updateIcon(target.classList.contains('show'));
-
-      target.addEventListener('show.bs.collapse', () => updateIcon(true));
-      target.addEventListener('hide.bs.collapse', () => updateIcon(false));
-    });
-  });
-</script>
+<script src="{$base_url}/js/dashboard.js"></script>
 {/block}

--- a/templates/layouts/layout.tpl
+++ b/templates/layouts/layout.tpl
@@ -29,7 +29,7 @@
   </div>
   <nav class="header-auth-links">
     {if $isLoggedIn}
-      <span class="me-3">Willkommen, {$username}!</span>
+      <span class="me-3">Willkommen, {$username|escape}!</span>
       <a href="{$base_url}/logout.php" class="btn btn-sm btn-outline-secondary">Logout</a>
     {else}
       <a href="#" class="btn btn-sm btn-primary me-2" data-bs-toggle="modal" data-bs-target="#loginModal">Login</a>


### PR DESCRIPTION
## Summary
- add learn timer controls to `dashboard.tpl`
- include countdown modal with alarm
- move JS logic to new `dashboard.js`
- escape usernames to prevent XSS

## Testing
- `composer validate --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685281e060348332a08a808bb83cd4e1