### PR TITLE
Add priority to ToDos

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -329,6 +329,19 @@ class DbFunctions
     }
 
     /**
+     * Aktualisiert die Priorität eines ToDos.
+     */
+    public static function updateTodoPriority(int $todoId, int $userId, string $priority): void
+    {
+        $query = '
+        UPDATE todos
+        SET priority = ?
+        WHERE id = ? AND user_id = ? AND is_done = 0
+    ';
+        self::execute($query, [$priority, $todoId, $userId]);
+    }
+
+    /**
      * Löscht ein erledigtes ToDo.
      */
     public static function deleteTodo(int $todoId, int $userId): void

--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -294,13 +294,13 @@ class DbFunctions
     /**
      * Legt ein neues ToDo an.
      */
-    public static function insertTodo(int $userId, string $text, ?string $dueDate): void
+    public static function insertTodo(int $userId, string $text, ?string $dueDate, string $priority = 'medium'): void
     {
         $query = '
-        INSERT INTO todos (user_id, text, due_date)
-        VALUES (?, ?, ?)
+        INSERT INTO todos (user_id, text, due_date, priority)
+        VALUES (?, ?, ?, ?)
     ';
-        self::execute($query, [$userId, $text, $dueDate]);
+        self::execute($query, [$userId, $text, $dueDate, $priority]);
     }
 
     /**
@@ -326,6 +326,30 @@ class DbFunctions
         WHERE id = ? AND user_id = ?
     ';
         self::execute($query, [$newStatus, $todoId, $userId]);
+    }
+
+    /**
+     * Löscht ein erledigtes ToDo.
+     */
+    public static function deleteTodo(int $todoId, int $userId): void
+    {
+        $query = '
+        DELETE FROM todos
+        WHERE id = ? AND user_id = ? AND is_done = 1
+    ';
+        self::execute($query, [$todoId, $userId]);
+    }
+
+    /**
+     * Löscht alle erledigten ToDos eines Benutzers.
+     */
+    public static function deleteCompletedTodos(int $userId): void
+    {
+        $query = '
+        DELETE FROM todos
+        WHERE user_id = ? AND is_done = 1
+    ';
+        self::execute($query, [$userId]);
     }
 
     /**Alle bestätigten Materialien abrufen**/

--- a/public/todos.php
+++ b/public/todos.php
@@ -18,6 +18,15 @@ if (empty($_SESSION['user_id'])) {
 $userId   = (int)$_SESSION['user_id'];
 $showDone = isset($_GET['show_done']) && $_GET['show_done'] == '1';
 
+// Priorität eines offenen ToDos aktualisieren
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_priority'])) {
+    $todoId  = (int)$_POST['todo_id'];
+    $priority = $_POST['priority'] ?? 'medium';
+    DbFunctions::updateTodoPriority($todoId, $userId, $priority);
+    header('Location: todos.php');
+    exit;
+}
+
 // Neues ToDo hinzufügen, inklusive Fälligkeitsdatum
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['new_todo'])) {
     $text = trim($_POST['new_todo']);

--- a/public/todos.php
+++ b/public/todos.php
@@ -22,9 +22,10 @@ $showDone = isset($_GET['show_done']) && $_GET['show_done'] == '1';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['new_todo'])) {
     $text = trim($_POST['new_todo']);
     $dueDate = !empty($_POST['due_date']) ? $_POST['due_date'] : null;
+    $priority = $_POST['priority'] ?? 'medium';
 
     if ($text !== '') {
-        DbFunctions::insertTodo($userId, $text, $dueDate); 
+        DbFunctions::insertTodo($userId, $text, $dueDate, $priority);
     }
 
     // Nach dem Hinzufügen neu laden (Vermeidung von POST-Resubmits)
@@ -50,6 +51,21 @@ if (isset($_GET['toggle'])) {
     }
     
     header("Location: todos.php");
+    exit;
+}
+
+// Einzelnes erledigtes ToDo löschen
+if (isset($_GET['delete'])) {
+    $todoId = (int)$_GET['delete'];
+    DbFunctions::deleteTodo($todoId, $userId);
+    header('Location: todos.php?show_done=1');
+    exit;
+}
+
+// Alle erledigten ToDos löschen
+if (isset($_GET['delete_completed'])) {
+    DbFunctions::deleteCompletedTodos($userId);
+    header('Location: todos.php?show_done=1');
     exit;
 }
 

--- a/sql/alter_add_priority_to_todos.sql
+++ b/sql/alter_add_priority_to_todos.sql
@@ -1,0 +1,3 @@
+ALTER TABLE todos
+    ADD COLUMN priority ENUM('low', 'medium', 'high') NOT NULL DEFAULT 'medium' AFTER due_date;
+

--- a/templates/todos.tpl
+++ b/templates/todos.tpl
@@ -47,6 +47,16 @@
                         <span class="badge ms-2 {if $todo.priority=='high'}bg-danger{elseif $todo.priority=='medium'}bg-warning text-dark{else}bg-success{/if}">
                             {if $todo.priority=='high'}Hoch{elseif $todo.priority=='medium'}Mittel{else}Niedrig{/if}
                         </span>
+                        <form method="post" class="d-inline ms-2">
+                            <input type="hidden" name="update_priority" value="1">
+                            <input type="hidden" name="todo_id" value="{$todo.id}">
+                            <select name="priority" class="form-select form-select-sm d-inline-block w-auto me-1">
+                                <option value="high" {if $todo.priority=='high'}selected{/if}>Hoch</option>
+                                <option value="medium" {if $todo.priority=='medium'}selected{/if}>Mittel</option>
+                                <option value="low" {if $todo.priority=='low'}selected{/if}>Niedrig</option>
+                            </select>
+                            <button type="submit" class="btn btn-sm btn-outline-primary">Speichern</button>
+                        </form>
                     </div>
 
                     {* Link zum Togglen des Status (erledigt) *}

--- a/templates/todos.tpl
+++ b/templates/todos.tpl
@@ -103,12 +103,14 @@
                         </div>
 
                         {* Rückgängig-Link (erneutes Togglen auf "nicht erledigt") *}
-                        <a href="?toggle={$todo.id}&show_done=1" class="btn btn-sm btn-outline-danger">
-                            Rückgängig
-                        </a>
-                        <a href="?delete={$todo.id}&show_done=1" class="btn btn-sm btn-outline-secondary ms-2" onclick="return confirm('ToDo wirklich löschen?');">
-                            Löschen
-                        </a>
+                        <div class="d-flex gap-2">
+                            <a href="?toggle={$todo.id}&show_done=1" class="btn btn-sm btn-outline-danger">
+                                Rückgängig
+                            </a>
+                            <a href="?delete={$todo.id}&show_done=1" class="btn btn-sm btn-outline-secondary" onclick="return confirm('ToDo wirklich löschen?');">
+                                Löschen
+                            </a>
+                        </div>
                     </li>
                 {/foreach}
             </ul>

--- a/templates/todos.tpl
+++ b/templates/todos.tpl
@@ -44,7 +44,7 @@
                                 Fällig: {$todo.due_date|date_format:"%d.%m.%Y"}
                             </div>
                         {/if}
-                        <span class="badge ms-2 {if $todo.priority=='high'}bg-danger{elseif $todo.priority=='medium'}bg-warning text-dark{else}bg-secondary{/if}">
+                        <span class="badge ms-2 {if $todo.priority=='high'}bg-danger{elseif $todo.priority=='medium'}bg-warning text-dark{else}bg-success{/if}">
                             {if $todo.priority=='high'}Hoch{elseif $todo.priority=='medium'}Mittel{else}Niedrig{/if}
                         </span>
                     </div>
@@ -97,7 +97,7 @@
                                     Fällig: {$todo.due_date|date_format:"%d.%m.%Y"}
                                 </div>
                             {/if}
-                            <span class="badge ms-2 {if $todo.priority=='high'}bg-danger{elseif $todo.priority=='medium'}bg-warning text-dark{else}bg-secondary{/if}">
+                            <span class="badge ms-2 {if $todo.priority=='high'}bg-danger{elseif $todo.priority=='medium'}bg-warning text-dark{else}bg-success{/if}">
                                 {if $todo.priority=='high'}Hoch{elseif $todo.priority=='medium'}Mittel{else}Niedrig{/if}
                             </span>
                         </div>

--- a/templates/todos.tpl
+++ b/templates/todos.tpl
@@ -10,11 +10,18 @@
         Optional kann ein Fälligkeitsdatum mitgegeben werden.*}
     <form method="post" class="mb-4">
         <div class="row g-2">
-            <div class="col-md-8">
+            <div class="col-md-6">
                 <input type="text" name="new_todo" class="form-control" placeholder="Neues ToDo..." required>
             </div>
             <div class="col-md-3">
                 <input type="date" name="due_date" class="form-control" placeholder="Fälligkeitsdatum">
+            </div>
+            <div class="col-md-2">
+                <select name="priority" class="form-select">
+                    <option value="high">Hoch</option>
+                    <option value="medium" selected>Mittel</option>
+                    <option value="low">Niedrig</option>
+                </select>
             </div>
             <div class="col-md-1">
                 <button type="submit" class="btn btn-primary w-100">+</button>
@@ -37,6 +44,9 @@
                                 Fällig: {$todo.due_date|date_format:"%d.%m.%Y"}
                             </div>
                         {/if}
+                        <span class="badge ms-2 {if $todo.priority=='high'}bg-danger{elseif $todo.priority=='medium'}bg-warning text-dark{else}bg-secondary{/if}">
+                            {if $todo.priority=='high'}Hoch{elseif $todo.priority=='medium'}Mittel{else}Niedrig{/if}
+                        </span>
                     </div>
 
                     {* Link zum Togglen des Status (erledigt) *}
@@ -65,6 +75,15 @@
         </button>
     </form>
 
+    {if $showDone && $todos_finished|@count > 0}
+        <form method="get" class="mb-3">
+            <input type="hidden" name="delete_completed" value="1">
+            <button type="submit" class="btn btn-danger" onclick="return confirm('Alle erledigten ToDos wirklich löschen?');">
+                Alle erledigten löschen
+            </button>
+        </form>
+    {/if}
+
     {if $showDone}
         {if $todos_finished|@count > 0}
             <ul class="list-group">
@@ -78,11 +97,17 @@
                                     Fällig: {$todo.due_date|date_format:"%d.%m.%Y"}
                                 </div>
                             {/if}
+                            <span class="badge ms-2 {if $todo.priority=='high'}bg-danger{elseif $todo.priority=='medium'}bg-warning text-dark{else}bg-secondary{/if}">
+                                {if $todo.priority=='high'}Hoch{elseif $todo.priority=='medium'}Mittel{else}Niedrig{/if}
+                            </span>
                         </div>
 
                         {* Rückgängig-Link (erneutes Togglen auf "nicht erledigt") *}
                         <a href="?toggle={$todo.id}&show_done=1" class="btn btn-sm btn-outline-danger">
                             Rückgängig
+                        </a>
+                        <a href="?delete={$todo.id}&show_done=1" class="btn btn-sm btn-outline-secondary ms-2" onclick="return confirm('ToDo wirklich löschen?');">
+                            Löschen
                         </a>
                     </li>
                 {/foreach}


### PR DESCRIPTION
## Summary
- support priority for todos
- expose priority dropdown in todo template
- display priority badges in todo lists
- update insertion logic to save priority
- provide SQL to add priority column
- allow deleting completed todos individually or all at once with confirmation

## Testing
- `php -l public/todos.php` *(fails: command not found)*
- `php -l includes/db.inc.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c2727d648332b108edc3f859c9b3