### PR TITLE
Fix browse query to ignore group uploads

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -335,7 +335,7 @@ class DbFunctions
         $query = '
         SELECT id, stored_name, material_id, uploaded_by
         FROM uploads
-        WHERE is_approved = 1
+        WHERE is_approved = 1 AND group_id IS NULL
     ';
         return self::execute($query, [], true); // true = fetchAll()
     }
@@ -348,7 +348,7 @@ class DbFunctions
         FROM materials m
         JOIN uploads u ON u.material_id = m.id
         JOIN courses c ON m.course_id = c.id
-        WHERE u.is_approved = 1
+        WHERE u.is_approved = 1 AND u.group_id IS NULL
     ';
     return self::execute($query, [], true);
 }
@@ -361,7 +361,7 @@ public static function getMaterialsByTitle(string $searchTerm): array
         FROM materials m
         JOIN uploads u ON u.material_id = m.id
         JOIN courses c ON m.course_id = c.id
-        WHERE u.is_approved = 1 AND m.title LIKE :search
+        WHERE u.is_approved = 1 AND u.group_id IS NULL AND m.title LIKE :search
     ');
     $stmt->execute(['search' => '%' . $searchTerm . '%']);
     return $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- filter approved uploads so that group uploads do not appear in the browse view
- update material queries to ignore uploads assigned to a group

## Testing
- `php -l includes/db.inc.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ccf2a86083328608be1c022ea6ed