### PR TITLE
Add user upload deletion

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -1414,6 +1414,30 @@ public static function getFilteredUploadLogs(array $filters, ?int $limit = null,
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
+
+    /**
+     * Löscht einen Upload des angegebenen Nutzers und gibt den Dateinamen
+     * zurück. Gibt null zurück, wenn der Upload nicht gefunden wurde.
+     */
+    public static function deleteUpload(int $uploadId, int $userId): ?string
+    {
+        $pdo = self::db_connect();
+
+        $stmt = $pdo->prepare('SELECT stored_name FROM uploads WHERE id = ? AND uploaded_by = ?');
+        $stmt->execute([$uploadId, $userId]);
+        $name = $stmt->fetchColumn();
+
+        if (!$name) {
+            return null;
+        }
+
+        $del = $pdo->prepare('DELETE FROM uploads WHERE id = ? AND uploaded_by = ?');
+        $del->execute([$uploadId, $userId]);
+
+        self::logUploadAction($uploadId, 'deleted', $userId, 'Upload gelöscht');
+
+        return $name;
+    }
 /**
  * Zählt die Anzahl der Upload-Logs mit erweiterten Filtermöglichkeiten.
  * @param array $filters Filterkriterien

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -26,6 +26,10 @@ $lockedUsers     = $isAdmin ? DbFunctions::getAllLockedUsers() : [];
 $pendingUploads  = DbFunctions::getPendingUploads();
 $pendingCourses  = DbFunctions::getPendingCourseSuggestions();
 $userUploads     = DbFunctions::getApprovedUploadsByUser((int)$_SESSION['user_id']);
+
+if (!isset($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
 // Dateityp fuer Vorschau bestimmen
 foreach ($userUploads as &$upload) {
     $ext = strtolower(pathinfo($upload['stored_name'], PATHINFO_EXTENSION));
@@ -53,6 +57,7 @@ $smarty->assign('pending_courses',  $pendingCourses);
 $smarty->assign('user_uploads',     $userUploads);
 $smarty->assign('isAdmin',          $isAdmin);
 $smarty->assign('isMod',            $isMod);
+$smarty->assign('csrf_token',       $_SESSION['csrf_token']);
 
 // Seite anzeigen
 $smarty->display('dashboard.tpl');

--- a/public/delete_upload.php
+++ b/public/delete_upload.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../includes/config.inc.php';
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || empty($_SESSION['user_id'])) {
+    http_response_code(403);
+    exit('Zugriff verweigert.');
+}
+
+if (empty($_POST['csrf_token']) || !isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], (string)$_POST['csrf_token'])) {
+    http_response_code(403);
+    exit('Ungültiger CSRF-Token.');
+}
+
+$uploadId = (int)($_POST['upload_id'] ?? 0);
+if ($uploadId <= 0) {
+    http_response_code(400);
+    exit('Ungültige ID.');
+}
+
+$userId = (int)$_SESSION['user_id'];
+
+try {
+    $storedName = DbFunctions::deleteUpload($uploadId, $userId);
+    if ($storedName === null) {
+        http_response_code(403);
+        exit('Upload nicht gefunden oder keine Berechtigung.');
+    }
+
+    $file = __DIR__ . '/../uploads/' . $storedName;
+    if (is_file($file)) {
+        unlink($file);
+    }
+
+    $_SESSION['flash'] = ['type' => 'success', 'message' => 'Upload wurde gelöscht.'];
+} catch (Exception $e) {
+    $_SESSION['flash'] = ['type' => 'danger', 'message' => 'Fehler beim Löschen des Uploads.'];
+}
+
+header('Location: dashboard.php');
+exit;

--- a/templates/dashboard.tpl
+++ b/templates/dashboard.tpl
@@ -302,14 +302,20 @@
                 <p>{$u.course_name|escape} – {$u.uploaded_at|date_format:"%d.%m.%Y %H:%M"}</p>
               </a>
 
-              <a href="{$base_url}/download.php?id={$u.id}" 
-                 class="download-link mt-3" 
+              <a href="{$base_url}/download.php?id={$u.id}"
+                 class="download-link mt-3"
                  title="{$u.original_name|escape} herunterladen"
                  download>
                 <span class="material-symbols-outlined">download</span>
                 <span>Herunterladen</span>
                 <small class="text-muted d-block mt-1"></small>
               </a>
+
+              <form method="post" action="{$base_url}/delete_upload.php" class="mt-2">
+                <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                <input type="hidden" name="upload_id" value="{$u.id}">
+                <button type="submit" class="btn btn-sm btn-danger">Löschen</button>
+              </form>
             </div>
           </div>
           {/foreach}

--- a/templates/dashboard.tpl
+++ b/templates/dashboard.tpl
@@ -311,7 +311,7 @@
                 <small class="text-muted d-block mt-1"></small>
               </a>
 
-              <form method="post" action="{$base_url}/delete_upload.php" class="mt-2">
+              <form method="post" action="{$base_url}/delete_upload.php" class="mt-2" onsubmit="return confirm('Upload wirklich löschen?');">
                 <input type="hidden" name="csrf_token" value="{$csrf_token}">
                 <input type="hidden" name="upload_id" value="{$u.id}">
                 <button type="submit" class="btn btn-sm btn-danger">Löschen</button>


### PR DESCRIPTION
## Summary
- allow users to remove their own uploads
- record deletion in the database via new function `deleteUpload`
- expose CSRF token on dashboard for deletion form
- add deletion option to dashboard carousel

## Testing
- `php -l public/delete_upload.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852c31b856c8332a6be02fc2a045314