### PR TITLE
Add group invite feature

### DIFF
--- a/includes/config.inc.php
+++ b/includes/config.inc.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../includes/db.inc.php';
 require_once __DIR__ . '/../includes/ip_utils.inc.php';
 require_once __DIR__ . '/../includes/recaptcha.inc.php';
 require_once __DIR__ . '/../includes/mailing.inc.php';
+require_once __DIR__ . '/../includes/group_invites.inc.php';
 require_once __DIR__ . '/../includes/central_logs.inc.php';
 require_once __DIR__ . '/../includes/crypto.inc.php';
 require_once __DIR__ . '/../includes/logger.inc.php';

--- a/includes/group_invites.inc.php
+++ b/includes/group_invites.inc.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/mailing.inc.php';
+
+function sendGroupInviteEmail(string $toEmail, string $toName, string $groupName, string $inviterName, string $token): void
+{
+    global $config;
+
+    $siteUrl = $config['site_url'] ?? $config['base_url'] ?? '';
+    if (!$siteUrl) {
+        throw new RuntimeException('site_url nicht gesetzt');
+    }
+
+    $link = rtrim($siteUrl, '/') . '/join_group.php?token=' . urlencode($token);
+
+    $subject = 'Einladung zur Lerngruppe ' . $groupName;
+    $groupEsc = htmlspecialchars($groupName, ENT_QUOTES);
+    $inviterEsc = htmlspecialchars($inviterName, ENT_QUOTES);
+
+    $htmlBody = "<p>Hallo <strong>{$toName}</strong>,</p>" .
+        "<p>{$inviterEsc} hat dich zur Lerngruppe <strong>{$groupEsc}</strong> eingeladen.</p>" .
+        '<p>Klicke auf folgenden Link, um beizutreten (gültig 48 Stunden):</p>' .
+        "<p><a href=\"{$link}\">Jetzt beitreten</a></p>" .
+        '<p>Viele Grüße,<br>StudyHub-Team</p>';
+
+    $altBody = "Hallo {$toName},\n\n" .
+        "$inviterName hat dich zur Lerngruppe '{$groupName}' eingeladen.\n" .
+        "Nutze folgenden Link, um beizutreten:\n{$link}\n\n" .
+        "Viele Grüße,\nStudyHub-Team";
+
+    sendMail($toEmail, $toName, $subject, $htmlBody, $altBody);
+}

--- a/public/gruppe.php
+++ b/public/gruppe.php
@@ -60,6 +60,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         DbFunctions::removeUserFromGroup($groupId, $uid);
         $success = 'Mitglied entfernt.';
     }
+    // Benutzer einladen (nur Admin)
+    elseif (isset($_POST['invite_user']) && $myRole === 'admin') {
+        $username = trim($_POST['invite_username'] ?? '');
+        if ($username === '') {
+            $error = 'Bitte gib einen Benutzernamen ein.';
+        } else {
+            $invUser = DbFunctions::fetchUserByIdentifier($username);
+            if (!$invUser) {
+                $error = 'Benutzer nicht gefunden.';
+            } elseif (DbFunctions::fetchUserRoleInGroup($groupId, (int)$invUser['id'])) {
+                $error = 'Benutzer ist bereits Mitglied.';
+            } elseif (DbFunctions::fetchActiveGroupInvite($groupId, (int)$invUser['id'])) {
+                $error = 'Es besteht bereits eine aktive Einladung.';
+            } else {
+                $token = bin2hex(random_bytes(32));
+                if (DbFunctions::createGroupInvite($groupId, (int)$invUser['id'], $token)) {
+                    sendGroupInviteEmail(
+                        $invUser['email'],
+                        $invUser['username'],
+                        $group['name'],
+                        $_SESSION['username'],
+                        $token
+                    );
+                    $success = 'Einladung versendet.';
+                } else {
+                    $error = 'Einladung konnte nicht erstellt werden.';
+                }
+            }
+        }
+    }
     // Upload-Link
     elseif (isset($_POST['upload_group']) && $myRole !== 'none') {
         header("Location: upload.php?group_id={$groupId}");

--- a/public/gruppe.php
+++ b/public/gruppe.php
@@ -66,27 +66,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($username === '') {
             $error = 'Bitte gib einen Benutzernamen ein.';
         } else {
-            $invUser = DbFunctions::fetchUserByIdentifier($username);
-            if (!$invUser) {
-                $error = 'Benutzer nicht gefunden.';
-            } elseif (DbFunctions::fetchUserRoleInGroup($groupId, (int)$invUser['id'])) {
-                $error = 'Benutzer ist bereits Mitglied.';
-            } elseif (DbFunctions::fetchActiveGroupInvite($groupId, (int)$invUser['id'])) {
-                $error = 'Es besteht bereits eine aktive Einladung.';
-            } else {
-                $token = bin2hex(random_bytes(32));
-                if (DbFunctions::createGroupInvite($groupId, (int)$invUser['id'], $token)) {
-                    sendGroupInviteEmail(
-                        $invUser['email'],
-                        $invUser['username'],
-                        $group['name'],
-                        $_SESSION['username'],
-                        $token
-                    );
-                    $success = 'Einladung versendet.';
+            try {
+                $invUser = DbFunctions::fetchUserByIdentifier($username);
+                if (!$invUser) {
+                    $error = 'Benutzer nicht gefunden.';
+                } elseif (DbFunctions::fetchUserRoleInGroup($groupId, (int)$invUser['id'])) {
+                    $error = 'Benutzer ist bereits Mitglied.';
+                } elseif (DbFunctions::fetchActiveGroupInvite($groupId, (int)$invUser['id'])) {
+                    $error = 'Es besteht bereits eine aktive Einladung.';
                 } else {
-                    $error = 'Einladung konnte nicht erstellt werden.';
+                    $token = bin2hex(random_bytes(32));
+                    if (DbFunctions::createGroupInvite($groupId, (int)$invUser['id'], $token)) {
+                        sendGroupInviteEmail(
+                            $invUser['email'],
+                            $invUser['username'],
+                            $group['name'],
+                            $_SESSION['username'],
+                            $token
+                        );
+                        $success = 'Einladung versendet.';
+                    } else {
+                        $error = 'Einladung konnte nicht erstellt werden.';
+                    }
                 }
+            } catch (Throwable $e) {
+                $log = LoggerFactory::get('gruppe');
+                $log->error('Invite user failed', ['error' => $e->getMessage()]);
+                $error = 'Fehler beim Versenden der Einladung.';
             }
         }
     }

--- a/public/join_group.php
+++ b/public/join_group.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../includes/config.inc.php';
+
+$log = LoggerFactory::get('join_group');
+
+if (empty($_SESSION['user_id'])) {
+    $reason = urlencode('Du musst eingeloggt sein, um einer Gruppe beizutreten.');
+    header("Location: /studyhub/error/403?reason={$reason}&action=both");
+    exit;
+}
+
+$token = trim((string)($_GET['token'] ?? ''));
+
+$data = [
+    'alertType'  => 'danger',
+    'message'    => 'Ungültiger Einladungslink.',
+    'showButton' => true,
+    'buttonText' => 'Zur Startseite',
+    'buttonLink' => 'index.php',
+];
+
+try {
+    if ($token === '') {
+        throw new RuntimeException('Token fehlt');
+    }
+
+    $invite = DbFunctions::fetchGroupInviteByToken($token);
+    if (!$invite) {
+        throw new RuntimeException('Einladung ungültig oder abgelaufen');
+    }
+
+    if ((int)$invite['invited_user_id'] !== (int)$_SESSION['user_id']) {
+        throw new RuntimeException('Diese Einladung ist nicht f\xC3\xBCr deinen Account.');
+    }
+
+    DbFunctions::addUserToGroup((int)$invite['group_id'], (int)$invite['invited_user_id']);
+    DbFunctions::setUserRoleInGroup((int)$invite['group_id'], (int)$invite['invited_user_id'], 'member');
+    DbFunctions::markGroupInviteUsed((int)$invite['id']);
+
+    $group = DbFunctions::fetchGroupById((int)$invite['group_id']);
+
+    $data['alertType']  = 'success';
+    $data['message']    = 'Du bist der Gruppe ' . htmlspecialchars($group['name'], ENT_QUOTES) . ' beigetreten.';
+    $data['buttonText'] = 'Zur Gruppe';
+    $data['buttonLink'] = 'gruppe.php?id=' . (int)$invite['group_id'];
+} catch (Throwable $e) {
+    $log->error('join_group failed', ['error' => $e->getMessage()]);
+}
+
+$smarty->assign($data);
+$smarty->display('join_group.tpl');

--- a/sql/create_group_invites_table.sql
+++ b/sql/create_group_invites_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE group_invites (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    group_id INT NOT NULL,
+    invited_user_id INT NOT NULL,
+    token VARCHAR(64) NOT NULL UNIQUE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    used_at DATETIME NULL DEFAULT NULL,
+    expires_at DATETIME NOT NULL,
+    CONSTRAINT fk_inv_group FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE,
+    CONSTRAINT fk_inv_user FOREIGN KEY (invited_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_inv_group_user (group_id, invited_user_id)
+);

--- a/templates/dashboard.tpl
+++ b/templates/dashboard.tpl
@@ -5,7 +5,7 @@
 {block name="content"}
 <div class="container mt-5">
   <h1>
-    Hallo, {$username}!<br>
+    Hallo, {$username|escape}!<br>
     <small class="text-muted">
         Rolle:
         {if $isAdmin}

--- a/templates/edit_profile.tpl
+++ b/templates/edit_profile.tpl
@@ -11,7 +11,7 @@
     {* PROFILBILD OBEN + LÖSCHBUTTON *}
     <div class="text-center mb-4">
         {if $profile.profile_picture}
-            <img src="{$base_url}/uploads/profile_pictures/{$profile.profile_picture}" alt="Profilbild"
+            <img src="{$base_url}/uploads/profile_pictures/{$profile.profile_picture|escape}" alt="Profilbild"
                  class="rounded-circle shadow mb-2" style="max-width: 150px; display: block; margin: 0 auto;">
             <div>
                 <form method="post" action="delete_profile_picture.php" class="d-inline-block mt-2">
@@ -42,53 +42,53 @@
 
         <div class="mb-3">
             <label for="first_name" class="form-label">Vorname</label>
-            <input type="text" class="form-control" name="first_name" value="{$profile.first_name}">
+            <input type="text" class="form-control" name="first_name" value="{$profile.first_name|escape}">
         </div>
 
         <div class="mb-3">
             <label for="last_name" class="form-label">Nachname</label>
-            <input type="text" class="form-control" name="last_name" value="{$profile.last_name}">
+            <input type="text" class="form-control" name="last_name" value="{$profile.last_name|escape}">
         </div>
 
         <div class="mb-3">
             <label for="email" class="form-label">E-Mail</label>
-            <input type="email" class="form-control" name="email" value="{$email}">
+            <input type="email" class="form-control" name="email" value="{$email|escape}">
         </div>
 
         <div class="mb-3">
             <label for="birthdate" class="form-label">Geburtsdatum</label>
-            <input type="date" class="form-control" name="birthdate" value="{$profile.birthdate}">
+            <input type="date" class="form-control" name="birthdate" value="{$profile.birthdate|escape}">
         </div>
 
         <div class="mb-3">
             <label for="location" class="form-label">Wohnort</label>
-            <input type="text" class="form-control" name="location" value="{$profile.location}">
+            <input type="text" class="form-control" name="location" value="{$profile.location|escape}">
         </div>
 
         <div class="mb-3">
             <label for="about_me" class="form-label">Über mich</label>
-            <textarea class="form-control" name="about_me" rows="4">{$profile.about_me}</textarea>
+            <textarea class="form-control" name="about_me" rows="4">{$profile.about_me|escape}</textarea>
         </div>
 
         {* Netzwerke als reine Texteingabe (kein Link) *}
         <div class="mb-3">
             <label for="instagram" class="form-label">Instagram</label>
-            <input type="text" class="form-control" name="instagram" value="{$profile.instagram}">
+            <input type="text" class="form-control" name="instagram" value="{$profile.instagram|escape}">
         </div>
 
         <div class="mb-3">
             <label for="tiktok" class="form-label">TikTok</label>
-            <input type="text" class="form-control" name="tiktok" value="{$profile.tiktok}">
+            <input type="text" class="form-control" name="tiktok" value="{$profile.tiktok|escape}">
         </div>
 
         <div class="mb-3">
             <label for="discord" class="form-label">Discord</label>
-            <input type="text" class="form-control" name="discord" value="{$profile.discord}">
+            <input type="text" class="form-control" name="discord" value="{$profile.discord|escape}">
         </div>
 
         <div class="mb-3">
             <label for="ms_teams" class="form-label">MS Teams</label>
-            <input type="text" class="form-control" name="ms_teams" value="{$profile.ms_teams}">
+            <input type="text" class="form-control" name="ms_teams" value="{$profile.ms_teams|escape}">
         </div>
 
         <button type="submit" class="btn btn-success">Speichern</button>

--- a/templates/gruppe.tpl
+++ b/templates/gruppe.tpl
@@ -41,6 +41,16 @@
     {/foreach}
   </ul>
 
+  {if $myRole === 'admin'}
+    <h4>Benutzer einladen</h4>
+    <form method="post" class="mb-4">
+      <div class="mb-3">
+        <input type="text" name="invite_username" class="form-control" placeholder="Benutzername" required>
+      </div>
+      <button name="invite_user" class="btn btn-primary">Einladen</button>
+    </form>
+  {/if}
+
   <h3>Materialien</h3>
   {if $uploads|@count}
     <ul class="list-group mb-3">

--- a/templates/join_group.tpl
+++ b/templates/join_group.tpl
@@ -1,0 +1,13 @@
+{extends file="./layouts/layout.tpl"}
+{block name="title"}Gruppen-Einladung{/block}
+
+{block name="content"}
+  <div class="container my-5">
+    <div class="alert alert-{$alertType} text-center" role="alert">
+      <p class="mb-3">{$message}</p>
+      {if $showButton}
+        <a href="{$buttonLink}" class="btn btn-primary">{$buttonText}</a>
+      {/if}
+    </div>
+  </div>
+{/block}

--- a/templates/layouts/layout.tpl
+++ b/templates/layouts/layout.tpl
@@ -29,7 +29,7 @@
   </div>
   <nav class="header-auth-links">
     {if $isLoggedIn}
-      <span class="me-3">Willkommen, {$username}!</span>
+      <span class="me-3">Willkommen, {$username|escape}!</span>
       <a href="{$base_url}/logout.php" class="btn btn-sm btn-outline-secondary">Logout</a>
     {else}
       <a href="#" class="btn btn-sm btn-primary me-2" data-bs-toggle="modal" data-bs-target="#loginModal">Login</a>

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -7,7 +7,7 @@
     {if $isOwnProfile}
         Mein Profil
     {else}
-        Profil von {$profile.username}
+        Profil von {$profile.username|escape}
     {/if}
 </h1>
 
@@ -17,7 +17,7 @@
         {* PROFILBILD OBEN *}
         <div class="text-center mb-4">
             {if $profile.profile_picture}
-                <img src="{$base_url}/uploads/profile_pictures/{$profile.profile_picture}" alt="Profilbild"
+                <img src="{$base_url}/uploads/profile_pictures/{$profile.profile_picture|escape}" alt="Profilbild"
                      class="rounded-circle shadow mb-2" style="max-width: 150px;">
             {else}
                 <img src="{$base_url}/assets/default_person.png" alt="Kein Profilbild"
@@ -29,13 +29,13 @@
         <div class="card mb-4">
             <div class="card-body">
                 <strong>Benutzername:</strong>
-                <p class="text-muted">{$profile.username}</p>
+                <p class="text-muted">{$profile.username|escape}</p>
 
                 <strong>Vorname:</strong>
-                <p class="text-muted">{$profile.first_name}</p>
+                <p class="text-muted">{$profile.first_name|escape}</p>
 
                 <strong>Nachname:</strong>
-                <p class="text-muted">{$profile.last_name}</p>
+                <p class="text-muted">{$profile.last_name|escape}</p>
 
                 <strong>Geburtsdatum:</strong>
                 <p class="text-muted">
@@ -43,18 +43,18 @@
                 </p>
 
                 <strong>Wohnort:</strong>
-                <p class="text-muted">{$profile.location}</p>
+                <p class="text-muted">{$profile.location|escape}</p>
 
                 <strong>Über mich:</strong>
-                <p class="text-muted">{$profile.about_me|default:"Noch nichts eingetragen."}</p>
+                <p class="text-muted">{$profile.about_me|default:"Noch nichts eingetragen."|escape}</p>
 
                 {if $profile.instagram || $profile.tiktok || $profile.discord || $profile.ms_teams}
                     <strong>Andere Netzwerke:</strong>
                     <ul class="text-muted list-unstyled">
-                        {if $profile.instagram}<li>📸 Instagram: {$profile.instagram}</li>{/if}
-                        {if $profile.tiktok}<li>🎵 TikTok: {$profile.tiktok}</li>{/if}
-                        {if $profile.discord}<li>💬 Discord: {$profile.discord}</li>{/if}
-                        {if $profile.ms_teams}<li>🧑‍💼 MS Teams: {$profile.ms_teams}</li>{/if}
+                        {if $profile.instagram}<li>📸 Instagram: {$profile.instagram|escape}</li>{/if}
+                        {if $profile.tiktok}<li>🎵 TikTok: {$profile.tiktok|escape}</li>{/if}
+                        {if $profile.discord}<li>💬 Discord: {$profile.discord|escape}</li>{/if}
+                        {if $profile.ms_teams}<li>🧑‍💼 MS Teams: {$profile.ms_teams|escape}</li>{/if}
                     </ul>
                 {/if}
             </div>
@@ -70,11 +70,11 @@
             <h3 class="mb-3">Zwei-Faktor-Authentifizierung</h3>
 
             {if $success}
-                <div class="alert alert-success">{$success}</div>
+                <div class="alert alert-success">{$success|escape}</div>
             {/if}
 
             {if $message}
-                <div class="alert alert-danger">{$message}</div>
+                <div class="alert alert-danger">{$message|escape}</div>
             {/if}
 
             {if $twofa_enabled}
@@ -159,10 +159,10 @@
             <hr class="my-5">
             <h3 class="mb-3">Passwort ändern</h3>
             {if isset($pw_success)}
-                <div class="alert alert-success">{$pw_success}</div>
+                <div class="alert alert-success">{$pw_success|escape}</div>
             {/if}
             {if isset($pw_message)}
-                <div class="alert alert-danger">{$pw_message}</div>
+                <div class="alert alert-danger">{$pw_message|escape}</div>
             {/if}
             <div id="pwFormAlert" class="alert alert-danger d-none">Bitte alle Felder ausfüllen.</div>
             <form id="pwChangeForm" method="post" class="needs-validation" novalidate>


### PR DESCRIPTION
## Summary
- create `group_invites` table SQL script
- send group invite emails via new helper
- support invites in DB layer
- process invites in `join_group.php`
- allow admins to invite users from group page
- display form for inviting users
- add join group result template
- include invite helper in config
- escape user-provided content in various templates

## Testing
- `composer validate --no-check-publish` *(fails: command not found)*
- `php -l includes/group_invites.inc.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852873e45ac8332a73352c106456b07