### PR TITLE
Add join type feature for groups

### DIFF
--- a/public/gruppe.php
+++ b/public/gruppe.php
@@ -32,12 +32,18 @@ $myRole = DbFunctions::fetchUserRoleInGroup($groupId, $userId) ?? 'none';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Beitreten
     if (isset($_POST['join_group']) && $myRole === 'none') {
-        if (DbFunctions::addUserToGroup($groupId, $userId)) {
-            DbFunctions::setUserRoleInGroup($groupId, $userId, 'member');
-            $success = 'Beigetreten.';
-            $myRole = 'member';
+        if ($group['join_type'] === 'open' || ($group['join_type'] === 'code' && ($_POST['invite_code'] ?? '') === $group['invite_code'])) {
+            if (DbFunctions::addUserToGroup($groupId, $userId)) {
+                DbFunctions::setUserRoleInGroup($groupId, $userId, 'member');
+                $success = 'Beigetreten.';
+                $myRole = 'member';
+            } else {
+                $error = 'Fehler beim Beitreten.';
+            }
+        } elseif ($group['join_type'] === 'code') {
+            $error = 'Ungültiger Einladungscode.';
         } else {
-            $error = 'Fehler beim Beitreten.';
+            $error = 'Dieser Gruppe kann nur per Einladung beigetreten werden.';
         }
     }
     // Verlassen

--- a/public/join_group.php
+++ b/public/join_group.php
@@ -34,11 +34,14 @@ try {
         throw new RuntimeException('Diese Einladung ist nicht f\xC3\xBCr deinen Account.');
     }
 
+    $group = DbFunctions::fetchGroupById((int)$invite['group_id']);
+    if (!$group || $group['join_type'] !== 'invite') {
+        throw new RuntimeException('Diese Gruppe erlaubt keinen Beitritt per Einladung.');
+    }
+
     DbFunctions::addUserToGroup((int)$invite['group_id'], (int)$invite['invited_user_id']);
     DbFunctions::setUserRoleInGroup((int)$invite['group_id'], (int)$invite['invited_user_id'], 'member');
     DbFunctions::markGroupInviteUsed((int)$invite['id']);
-
-    $group = DbFunctions::fetchGroupById((int)$invite['group_id']);
 
     $data['alertType']  = 'success';
     $data['message']    = 'Du bist der Gruppe ' . htmlspecialchars($group['name'], ENT_QUOTES) . ' beigetreten.';

--- a/public/lerngruppen.php
+++ b/public/lerngruppen.php
@@ -18,14 +18,25 @@ $success = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['create_group'])) {
         $groupName = trim($_POST['group_name'] ?? '');
+        $joinType  = $_POST['join_type'] ?? 'open';
+        $allowed   = ['open','invite','code'];
         if ($groupName === '') {
             $error = 'Bitte gib einen Gruppennamen ein.';
         } elseif (DbFunctions::fetchGroupByName($groupName)) {
             $error = 'Dieser Gruppenname ist bereits vergeben.';
+        } elseif (!in_array($joinType, $allowed, true)) {
+            $error = 'Ungültige Beitrittsart.';
         } else {
-            $newGroupId = DbFunctions::createGroup($groupName, $userId);
+            $inviteCode = null;
+            if ($joinType === 'code') {
+                $inviteCode = bin2hex(random_bytes(5));
+            }
+            $newGroupId = DbFunctions::createGroup($groupName, $userId, $joinType, $inviteCode);
             if ($newGroupId) {
                 $success = 'Die Gruppe wurde erfolgreich erstellt.';
+                if ($inviteCode) {
+                    $success .= ' Einladungscode: ' . htmlspecialchars($inviteCode, ENT_QUOTES);
+                }
             } else {
                 $error = 'Fehler: Gruppe konnte nicht erstellt werden.';
             }
@@ -40,7 +51,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $error = 'Keine Gruppe mit diesem Namen gefunden.';
             } else {
                 $groupId = (int)$group['id'];
-                if (DbFunctions::addUserToGroup($groupId, $userId)) {
+                if ($group['join_type'] !== 'open') {
+                    $error = 'Dieser Gruppe kann man nicht direkt beitreten.';
+                } elseif (DbFunctions::addUserToGroup($groupId, $userId)) {
                     DbFunctions::setUserRoleInGroup($groupId, $userId, 'member');
                     $success = 'Du bist der Gruppe beigetreten.';
                 } else {

--- a/sql/alter_add_join_type_to_groups.sql
+++ b/sql/alter_add_join_type_to_groups.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `groups`
+    ADD COLUMN `join_type` ENUM('open','invite','code') NOT NULL DEFAULT 'open' AFTER `name`,
+    ADD COLUMN `invite_code` VARCHAR(64) NULL AFTER `join_type`;

--- a/templates/group_create.tpl
+++ b/templates/group_create.tpl
@@ -1,0 +1,23 @@
+{extends file="./layouts/layout.tpl"}
+{block name="title"}Gruppe erstellen{/block}
+{block name="content"}
+<div class="container mt-5">
+  <h1 class="mb-4 text-center">Neue Gruppe erstellen</h1>
+  {if $error}<div class="alert alert-danger">{$error}</div>{/if}
+  {if $success}<div class="alert alert-success">{$success}</div>{/if}
+  <form method="post">
+    <div class="mb-3">
+      <input type="text" name="group_name" class="form-control" placeholder="Gruppenname" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Beitrittsart</label>
+      <select name="join_type" class="form-select">
+        <option value="open">Offen</option>
+        <option value="invite">Nur per Einladung</option>
+        <option value="code">Nur per Einladungscode</option>
+      </select>
+    </div>
+    <button name="create_group" class="btn btn-primary">Erstellen</button>
+  </form>
+</div>
+{/block}

--- a/templates/gruppe.tpl
+++ b/templates/gruppe.tpl
@@ -7,9 +7,26 @@
   {if $success}<div class="alert alert-success">{$success}</div>{/if}
 
   <h1 class="mb-4">{$group.name|escape}</h1>
+  {if $group.join_type === 'invite'}
+    <p class="text-muted">Beitritt nur per Einladung.</p>
+  {elseif $group.join_type === 'code'}
+    <p class="text-muted">Beitritt nur per Einladungscode.</p>
+    {if $myRole === 'admin'}
+      <div class="alert alert-info">Einladungscode: <code>{$group.invite_code|escape}</code></div>
+    {/if}
+  {/if}
 
   {if $myRole === 'none'}
-    <form method="post"><button name="join_group" class="btn btn-primary">Beitreten</button></form>
+    {if $group.join_type === 'open'}
+      <form method="post"><button name="join_group" class="btn btn-primary">Beitreten</button></form>
+    {elseif $group.join_type === 'code'}
+      <form method="post" class="mb-3">
+        <div class="mb-2"><input type="text" name="invite_code" class="form-control" placeholder="Einladungscode" required></div>
+        <button name="join_group" class="btn btn-primary">Beitreten</button>
+      </form>
+    {else}
+      <p class="text-muted">Beitritt nur per Einladung.</p>
+    {/if}
   {else}
     <form method="post" class="d-inline"><button name="leave_group" class="btn btn-outline-warning">Verlassen</button></form>
     {if $myRole === 'admin'}

--- a/templates/gruppe.tpl
+++ b/templates/gruppe.tpl
@@ -25,7 +25,7 @@
         <button name="join_group" class="btn btn-primary">Beitreten</button>
       </form>
     {else}
-      <p class="text-muted">Beitritt nur per Einladung.</p>
+      
     {/if}
   {else}
     <form method="post" class="d-inline"><button name="leave_group" class="btn btn-outline-warning">Verlassen</button></form>

--- a/templates/lerngruppen.tpl
+++ b/templates/lerngruppen.tpl
@@ -31,6 +31,14 @@
         <div class="mb-3">
           <input type="text" name="group_name" class="form-control" placeholder="Gruppenname" required>
         </div>
+        <div class="mb-3">
+          <label class="form-label">Beitrittsart</label>
+          <select name="join_type" class="form-select">
+            <option value="open">Offen</option>
+            <option value="invite">Nur per Einladung</option>
+            <option value="code">Nur per Einladungscode</option>
+          </select>
+        </div>
         <button name="create_group" class="btn btn-primary">Erstellen</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add join_type and invite_code to groups table
- support creating groups with various join options
- handle join logic for open, invite, and code types
- show join type and code in group templates
- provide new group creation template

## Testing
- `php` not available; no automated tests run

------
https://chatgpt.com/codex/tasks/task_e_6852e26080208332ab0d1b2b27a932d3