### PR TITLE
Update dashboard layout

### DIFF
--- a/templates/dashboard.tpl
+++ b/templates/dashboard.tpl
@@ -18,51 +18,57 @@
     </small>
   </h1>
 
-  {* Eigene Uploads *}
-  <section class="my-4">
-    <h2 class="mb-2">Deine Uploads</h2>
-    <div>
-      {if $user_uploads|@count > 0}
-        <div id="myUploadsCarousel" class="carousel slide" data-bs-interval="false">
-          <div class="carousel-inner">
-            {foreach $user_uploads as $index => $u}
-              <div class="carousel-item {if $index == 0}active{/if}">
-                <div class="pdf-slide">
-                  <a href="{$base_url}/view_pdf.php?file={$u.stored_name|escape:'url'}" target="_blank" class="pdf-link">
-                    {if $u.type == 'image'}
-                      <img src="{$base_url}/uploads/{$u.stored_name|escape:'url'}" alt="{$u.title|escape}" class="img-fluid mb-2" style="max-height:160px;">
-                    {else}
-                      <span class="material-symbols-outlined">picture_as_pdf</span>
-                    {/if}
-                    <h5>{$u.title|escape:'html'}</h5>
-                    <p>{$u.course_name|escape:'html'} – {$u.uploaded_at|date_format:"%d.%m.%Y %H:%M"}</p>
-                  </a>
-                  <a href="{$base_url}/download.php?id={$u.id}"
-                     class="download-link mt-3"
-                     title="{$u.original_name|escape} herunterladen"
-                     download>
-                    <span class="material-symbols-outlined">download</span>
-                    <span>Herunterladen</span>
-                    <small class="text-muted d-block mt-1"></small>
-                  </a>
+  {if !$isAdmin}
+    {* Eigene Uploads *}
+    <section class="my-4">
+      <h2 class="mb-2">Deine Uploads</h2>
+      <div>
+        {if $user_uploads|@count > 0}
+          <div id="myUploadsCarousel" class="carousel slide" data-bs-interval="false">
+            <div class="carousel-inner">
+              {foreach $user_uploads as $index => $u}
+                <div class="carousel-item {if $index == 0}active{/if}">
+                  <div class="pdf-slide">
+                    <a href="{$base_url}/view_pdf.php?file={$u.stored_name|escape:'url'}" target="_blank" class="pdf-link">
+                      {if $u.type == 'image'}
+                        <img src="{$base_url}/uploads/{$u.stored_name|escape:'url'}" alt="{$u.title|escape}" class="img-fluid mb-2" style="max-height:160px;">
+                      {else}
+                        <span class="material-symbols-outlined">picture_as_pdf</span>
+                      {/if}
+                      <h5>{$u.title|escape:'html'}</h5>
+                      <p>{$u.course_name|escape:'html'} – {$u.uploaded_at|date_format:"%d.%m.%Y %H:%M"}</p>
+                    </a>
+                    <a href="{$base_url}/download.php?id={$u.id}"
+                       class="download-link mt-3"
+                       title="{$u.original_name|escape} herunterladen"
+                       download>
+                      <span class="material-symbols-outlined">download</span>
+                      <span>Herunterladen</span>
+                      <small class="text-muted d-block mt-1"></small>
+                    </a>
+                    <form method="post" action="{$base_url}/delete_upload.php" class="mt-2" onsubmit="return confirm('Upload wirklich löschen?');">
+                      <input type="hidden" name="csrf_token" value="{$csrf_token}">
+                      <input type="hidden" name="upload_id" value="{$u.id}">
+                      <button type="submit" class="btn btn-sm btn-danger">Löschen</button>
+                    </form>
+                  </div>
                 </div>
-              </div>
-            {/foreach}
+              {/foreach}
+            </div>
+            <button class="carousel-control-prev" type="button" data-bs-target="#myUploadsCarousel" data-bs-slide="prev">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">Zurück</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#myUploadsCarousel" data-bs-slide="next">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">Weiter</span>
+            </button>
           </div>
-          <button class="carousel-control-prev" type="button" data-bs-target="#myUploadsCarousel" data-bs-slide="prev">
-            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Zurück</span>
-          </button>
-          <button class="carousel-control-next" type="button" data-bs-target="#myUploadsCarousel" data-bs-slide="next">
-            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Weiter</span>
-          </button>
-        </div>
-      {else}
-        <div class="alert alert-info">Du hast noch keine Materialien hochgeladen.</div>
-      {/if}
-    </div>
-  </section>
+        {else}
+          <div class="alert alert-info">Du hast noch keine Materialien hochgeladen.</div>
+        {/if}
+      </div>
+    </section>
 
   <div class="row row-cols-1 row-cols-md-2 g-4 my-4">
   <div class="col">
@@ -89,8 +95,8 @@
       {include file='partials/calendar_month.tpl'}
     </section>
   </div>
-</div>
-
+  </div>
+  {/if}
 
   {if $isAdmin}
     {* Abschnitt 1 : locked User *}


### PR DESCRIPTION
## Summary
- show user uploads at top of dashboard
- integrate image preview and calendar row
- remove old uploads section

## Testing
- `composer validate --no-check-all` *(fails: composer not installed)*
- `php -l public/dashboard.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852e877d1d483328ea66ed90d288436