### PR TITLE
Validate age 16+ in profile date

### DIFF
--- a/public/edit_profile.php
+++ b/public/edit_profile.php
@@ -34,6 +34,7 @@ $smarty->assign('username', $username);
 $smarty->assign('profile', $profile);
 $smarty->assign('email', $email);
 $smarty->assign('socials', $socials);
+$smarty->assign('max_birthdate', (new DateTime('-16 years'))->format('Y-m-d'));
 
 // Template anzeigen
 $smarty->display('edit_profile.tpl');

--- a/public/profile.php
+++ b/public/profile.php
@@ -100,6 +100,7 @@ $smarty->assign('username', $username);
 $smarty->assign('profile', $profile);
 $smarty->assign('socials', $socialEntries);
 $smarty->assign('isOwnProfile', $isOwnProfile);
+$smarty->assign('max_birthdate', (new DateTime('-16 years'))->format('Y-m-d'));
 $smarty->assign('isAdmin', $isAdmin);
 $smarty->assign('pw_success', $pwSuccess);
 $smarty->assign('pw_message', $pwMessage);

--- a/public/saveprofile.php
+++ b/public/saveprofile.php
@@ -18,11 +18,26 @@ $keys = ['first_name', 'last_name', 'birthdate', 'location', 'about_me'];
 
 foreach ($keys as $key) {
     $value = $_POST[$key] ?? null;
-    
+
     if ($key === 'birthdate' && trim($value) === '') {
         $data[$key] = null;
     } else {
         $data[$key] = trim($value);
+    }
+}
+
+if (!empty($data['birthdate'])) {
+    try {
+        $birthObj = new DateTime($data['birthdate']);
+        $minDate  = new DateTime('-16 years');
+
+        if ($birthObj > $minDate) {
+            exit('Du musst mindestens 16 Jahre alt sein.');
+        }
+
+        $data['birthdate'] = $birthObj->format('Y-m-d');
+    } catch (Throwable $e) {
+        exit('Ungültiges Geburtsdatum.');
     }
 }
 

--- a/public/update_profile.php
+++ b/public/update_profile.php
@@ -78,13 +78,31 @@ try {
             break;
 
         case 'update_personal':
-            $birthRaw = trim($_POST['birthdate'] ?? '');
+            $birthRaw   = trim($_POST['birthdate'] ?? '');
+            $birthdate  = null;
+
+            if ($birthRaw !== '') {
+                try {
+                    $birthObj = new DateTime($birthRaw);
+                    $minDate  = new DateTime('-16 years');
+
+                    if ($birthObj > $minDate) {
+                        throw new RuntimeException('Du musst mindestens 16 Jahre alt sein.');
+                    }
+
+                    $birthdate = $birthObj->format('Y-m-d');
+                } catch (Throwable $e) {
+                    throw new RuntimeException('Ungültiges Geburtsdatum.');
+                }
+            }
+
             $fields = [
                 'first_name' => trim($_POST['first_name'] ?? ''),
                 'last_name'  => trim($_POST['last_name'] ?? ''),
                 'about_me'   => trim($_POST['about_me'] ?? ''),
-                'birthdate'  => $birthRaw === '' ? null : $birthRaw,
+                'birthdate'  => $birthdate,
             ];
+
             DbFunctions::updateUserProfile($userId, $fields);
             $_SESSION['flash'] = ['type' => 'success', 'message' => 'Persönliche Daten aktualisiert.'];
             break;

--- a/templates/edit_profile.tpl
+++ b/templates/edit_profile.tpl
@@ -57,7 +57,7 @@
 
         <div class="mb-3">
             <label for="birthdate" class="form-label">Geburtsdatum</label>
-            <input type="date" class="form-control" name="birthdate" value="{$profile.birthdate|escape}">
+            <input type="date" class="form-control" name="birthdate" value="{$profile.birthdate|escape}" max="{$max_birthdate}">
         </div>
 
         <div class="mb-3">

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -183,7 +183,7 @@
           </div>
           <div class="mb-3">
             <label for="birthdate" class="form-label">Geburtsdatum</label>
-            <input type="date" class="form-control" id="birthdate" name="birthdate" value="{$profile.birthdate|escape}">
+            <input type="date" class="form-control" id="birthdate" name="birthdate" value="{$profile.birthdate|escape}" max="{$max_birthdate}">
           </div>
           <div class="mb-3">
             <label for="about_me_edit" class="form-label">About Me</label>


### PR DESCRIPTION
## Summary
- add age validation on profile updates
- pass maximum allowed birthdate to templates
- restrict birthdate inputs in templates

## Testing
- `php -l public/update_profile.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855168444a883328ba7716dc0b4c23b