### PR TITLE
Use flash alerts for profile picture upload errors

### DIFF
--- a/public/edit_profile.php
+++ b/public/edit_profile.php
@@ -35,6 +35,12 @@ $smarty->assign('profile', $profile);
 $smarty->assign('email', $email);
 $smarty->assign('socials', $socials);
 
+// Flash Message anzeigen
+if (isset($_SESSION['flash'])) {
+    $smarty->assign('flash', $_SESSION['flash']);
+    unset($_SESSION['flash']);
+}
+
 // Template anzeigen
 $smarty->display('edit_profile.tpl');
 

--- a/public/saveprofile.php
+++ b/public/saveprofile.php
@@ -58,7 +58,12 @@ if (!empty($_FILES['profile_picture']) && $_FILES['profile_picture']['error'] ==
     // Einige PHP-Konfigurationen melden PNGs als image/x-png
     $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/x-png'];
     if ($mimeType && !in_array($mimeType, $allowedTypes, true)) {
-        exit('❌ Ungültiger Bildtyp.');
+        $_SESSION['flash'] = [
+            'type'    => 'danger',
+            'message' => 'Ungültiger Bildtyp.'
+        ];
+        header('Location: edit_profile.php');
+        exit;
     }
     
     // Zielverzeichnis und Dateiname
@@ -73,7 +78,12 @@ if (!empty($_FILES['profile_picture']) && $_FILES['profile_picture']['error'] ==
     if (!move_uploaded_file($tmpName, $targetPath)) {
         // Fallback falls PHP das Tmpfile nicht als Upload erkennt
         if (!rename($tmpName, $targetPath)) {
-            exit('❌ Fehler beim Hochladen des Bildes.');
+            $_SESSION['flash'] = [
+                'type'    => 'danger',
+                'message' => 'Fehler beim Hochladen des Bildes.'
+            ];
+            header('Location: edit_profile.php');
+            exit;
         }
     }
 


### PR DESCRIPTION
## Summary
- show upload errors as flash alerts instead of plain exit text
- display flash messages on the profile edit page

## Testing
- `php -l public/saveprofile.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685516d07058833291809f220a845bfc