### PR TITLE
Implement similarity check for course suggestions

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -5,7 +5,13 @@ declare(strict_types=1);
 
 class DbFunctions
 {
-    private static ?PDO $pdo = null;    private static ?ILogger $log = null;
+    private static ?PDO $pdo = null;
+    private static ?ILogger $log = null;
+    private static array $courseSynonyms = [
+        'mathe' => 'mathematik',
+        'info'  => 'informatik',
+        'iksy2' => 'iksy 2'
+    ];
 
     private static function getLogger(): ILogger
     {
@@ -1690,6 +1696,45 @@ public static function submitCourseSuggestion(string $courseName, int $userId): 
     $stmt = $pdo->prepare("INSERT INTO pending_course_suggestions (course_name, user_id) VALUES (?, ?)");
     $stmt->execute([$courseName, $userId]);
 }
+
+    /**
+     * Normalisiert einen Kursnamen für Vergleichszwecke.
+     */
+    private static function canonicalCourseName(string $name): string
+    {
+        $norm = strtolower(preg_replace('/\s+/', '', $name));
+        if (isset(self::$courseSynonyms[$norm])) {
+            $norm = strtolower(preg_replace('/\s+/', '', self::$courseSynonyms[$norm]));
+        }
+        return $norm;
+    }
+
+    /**
+     * Prüft, ob ein ähnlicher Kurs bereits existiert.
+     * Gibt den gefundenen Kursnamen zurück oder null.
+     */
+    public static function findSimilarCourse(string $courseName): ?string
+    {
+        $pdo = self::db_connect();
+        $stmt = $pdo->query('SELECT name FROM courses');
+        $courses = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $target = self::canonicalCourseName($courseName);
+
+        foreach ($courses as $c) {
+            $norm = self::canonicalCourseName($c);
+            if ($target === $norm) {
+                return $c;
+            }
+            if (levenshtein($target, $norm) <= 2) {
+                return $c;
+            }
+            if (soundex($target) === soundex($norm)) {
+                return $c;
+            }
+        }
+
+        return null;
+    }
 /* * Zählt die Anzahl der Einträge in der Tabelle upload_logs
  * mit erweiterten Filtermöglichkeiten.
  */

--- a/templates/upload.tpl
+++ b/templates/upload.tpl
@@ -8,6 +8,9 @@
     {if isset($error)}
     <div class="alert alert-danger">{$error}</div>
     {/if}
+    {if isset($warning)}
+    <div class="alert alert-warning">{$warning}</div>
+    {/if}
     {if isset($success)}
     <div class="alert alert-success">{$success}</div>
     {/if}
@@ -79,6 +82,9 @@
     <form id="suggest-form" action="{$base_url}/upload.php" method="post" style="display:none;">
         <input type="hidden" name="csrf_token" value="{$csrf_token}">
         <input type="hidden" name="action" value="suggest">
+        {if isset($warning)}
+        <input type="hidden" name="confirm_similar" value="1">
+        {/if}
 
         <div class="mb-3">
             <label for="course_suggestion" class="form-label">Kursname</label>


### PR DESCRIPTION
## Summary
- add mapping of course name synonyms
- add helper to find similar courses using normalization, Levenshtein and soundex
- warn user if a similar course exists when suggesting
- allow confirming the suggestion despite similarity via hidden field

## Testing
- `php -l public/upload.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a86f726e48332843a7a402561320d