### PR TITLE
Add copy button for group invite codes

### DIFF
--- a/templates/gruppe.tpl
+++ b/templates/gruppe.tpl
@@ -12,7 +12,10 @@
   {elseif $group.join_type === 'code'}
     <p class="text-muted">Beitritt per Einladungscode oder Einladung.</p>
     {if $myRole === 'admin'}
-      <div class="alert alert-info">Einladungscode: <code>{$group.invite_code|escape}</code></div>
+      <div class="alert alert-info d-flex align-items-center">
+        <span>Einladungscode: <code id="inviteCode">{$group.invite_code|escape}</code></span>
+        <button type="button" class="btn btn-outline-secondary btn-sm ms-2" id="copyInviteCode" data-code="{$group.invite_code|escape}">Kopieren</button>
+      </div>
     {/if}
   {/if}
 
@@ -97,4 +100,16 @@
     <form method="post"><button name="upload_group" class="btn btn-success">Für Lerngruppe hochladen</button></form>
   {/if}
 </div>
+{/block}
+
+{block name="scripts"}
+<script>
+  document.getElementById('copyInviteCode')?.addEventListener('click', function() {
+    const code = this.dataset.code;
+    navigator.clipboard.writeText(code).then(() => {
+      this.textContent = 'Kopiert!';
+      setTimeout(() => { this.textContent = 'Kopieren'; }, 2000);
+    });
+  });
+</script>
 {/block}


### PR DESCRIPTION
## Summary
- add a button to copy the invitation code in group view
- include client-side script to copy code to clipboard

## Testing
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa2373bf88332b47ffe97425a3db1