### PR TITLE
Switch scripts to handle_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Passwort = Acces Key
 
 # Custom Fehlerseiten konfigurieren
 
-Um das System für die Verwendung eigener Fehlerseiten (z. B. `404.tpl`, `403.tpl` etc.) korrekt einzurichten, kann das mitgelieferte Setup-Skript verwendet werden.
+Um das System für die Verwendung eigener Fehlerseiten (z. B. `401.tpl`, `403.tpl`, `404.tpl` etc.) korrekt einzurichten, kann das mitgelieferte Setup-Skript verwendet werden.
+Nicht eingeloggte Nutzer sehen dabei einen 401-Fehler. Meldet sich ein normaler Benutzer an und ruft einen nur für Admins oder Moderatoren vorgesehenen Bereich auf, erscheint stattdessen ein 403-Fehler. Die 403-Seite weist nun ausdrücklich darauf hin, dass für die angeforderte Ressource die erforderlichen Rechte fehlen und bietet lediglich einen Button zurück zur Startseite an.
 
 ## Setup ausführen
 

--- a/config/htaccess.full
+++ b/config/htaccess.full
@@ -27,6 +27,7 @@ RewriteRule ^(.+)$ $1.php [QSA,L]
 RewriteRule ^(.*)$ router.php?page=$1 [QSA,L]
 
 # Fehlerseiten definieren
+ErrorDocument 401 /studyhub/error/401
 ErrorDocument 403 /studyhub/error/403
 ErrorDocument 404 /studyhub/error/404
 ErrorDocument 500 /studyhub/error/500

--- a/public/contact_request.php
+++ b/public/contact_request.php
@@ -6,9 +6,13 @@ require_once __DIR__ . '/../includes/config.inc.php';
 require_once __DIR__ . '/../includes/mailing.inc.php';
 
 // Admin-/Mod-Schutz
-if (empty($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', ['admin', 'mod'], true)) {
-    http_response_code(403);
-    exit('Zugriff verweigert.');
+if (empty($_SESSION['user_id'])) {
+    $reason = 'Nicht eingeloggt.';
+    handle_error(401, $reason, 'both');
+}
+if (!in_array($_SESSION['role'] ?? '', ['admin', 'mod'], true)) {
+    $reason = 'Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen.';
+    handle_error(403, $reason, 'both');
 }
 
 // Flash-Messages

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -14,7 +14,7 @@ if (
     $_SESSION['2fa_passed'] !== true
 ) {
     $reason = "Du musst vollständig eingeloggt sein, um das Dashboard zu nutzen.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 // Rollen prüfen

--- a/public/delete_profile_picture.php
+++ b/public/delete_profile_picture.php
@@ -16,8 +16,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_SESSION['user_id'], $_POST[
     
     // CSRF-Schutz
     if (!isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $csrfToken)) {
-        http_response_code(403);
-        exit('Ungültiger CSRF-Token');
+        $reason = 'Ungültiger CSRF-Token';
+        handle_error(403, $reason, 'both');
     }
     
     try {
@@ -45,11 +45,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_SESSION['user_id'], $_POST[
         exit;
         
     } catch (Throwable $e) {
-        http_response_code(500);
-        exit('Beim Löschen des Profilbilds ist ein Fehler aufgetreten.');
+        $reason = 'Beim Löschen des Profilbilds ist ein Fehler aufgetreten.';
+        handle_error(500, $reason);
     }
 }
 
 // Ungültiger Zugriff (z. B. direkter Aufruf)
-http_response_code(403);
-exit('Zugriff verweigert');
+$reason = 'Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen.';
+handle_error(403, $reason, 'both');

--- a/public/delete_upload.php
+++ b/public/delete_upload.php
@@ -4,19 +4,19 @@ require_once __DIR__ . '/../includes/config.inc.php';
 session_start();
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || empty($_SESSION['user_id'])) {
-    http_response_code(403);
-    exit('Zugriff verweigert.');
+    $reason = 'Zugriff verweigert.';
+    handle_error(401, $reason, 'both');
 }
 
 if (empty($_POST['csrf_token']) || !isset($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], (string)$_POST['csrf_token'])) {
-    http_response_code(403);
-    exit('Ungültiger CSRF-Token.');
+    $reason = 'Ungültiger CSRF-Token.';
+    handle_error(403, $reason, 'both');
 }
 
 $uploadId = (int)($_POST['upload_id'] ?? 0);
 if ($uploadId <= 0) {
-    http_response_code(400);
-    exit('Ungültige ID.');
+    $reason = 'Ungültige ID.';
+    handle_error(400, $reason);
 }
 
 $userId = (int)$_SESSION['user_id'];
@@ -24,8 +24,8 @@ $userId = (int)$_SESSION['user_id'];
 try {
     $storedName = DbFunctions::deleteUpload($uploadId, $userId);
     if ($storedName === null) {
-        http_response_code(403);
-        exit('Upload nicht gefunden oder keine Berechtigung.');
+        $reason = 'Upload nicht gefunden oder keine Berechtigung.';
+        handle_error(403, $reason, 'both');
     }
 
     $file = __DIR__ . '/../uploads/' . $storedName;

--- a/public/download.php
+++ b/public/download.php
@@ -6,31 +6,31 @@ session_start();
 
 // Optional: nur für eingeloggte Benutzer
 if (empty($_SESSION['user_id'])) {
-    http_response_code(403);
-    exit('Zugriff verweigert – bitte einloggen.');
+    $reason = 'Zugriff verweigert – bitte einloggen.';
+    handle_error(401, $reason, 'both');
 }
 
 // Parameter prüfen
 $uploadId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($uploadId <= 0) {
-    http_response_code(400);
-    exit('Ungültige ID.');
+    $reason = 'Ungültige ID.';
+    handle_error(400, $reason);
 }
 
 // Upload-Daten abrufen
 $upload = DbFunctions::getApprovedUploadById($uploadId);
 
 if (!$upload) {
-    http_response_code(404);
-    exit('Upload nicht gefunden oder nicht freigegeben.');
+    $reason = 'Upload nicht gefunden oder nicht freigegeben.';
+    handle_error(404, $reason);
 }
 
 $basePath = realpath(__DIR__ . '/../uploads/');
 $filePath = $basePath . DIRECTORY_SEPARATOR . $upload['stored_name'];
 
 if (!is_file($filePath)) {
-    http_response_code(404);
-    exit('Datei nicht gefunden.');
+    $reason = 'Datei nicht gefunden.';
+    handle_error(404, $reason);
 }
 
 // Content-Type und Download-Header setzen

--- a/public/edit_profile.php
+++ b/public/edit_profile.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../includes/config.inc.php';
 
 if (empty($_SESSION['user_id']) || empty($_SESSION['username'])) {
     $reason = 'Du musst eingeloggt sein, um dein Profil zu bearbeiten.';
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 $userId   = $_SESSION['user_id'];

--- a/public/error.php
+++ b/public/error.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../includes/config.inc.php';
 
 $code = (int)($_GET['code'] ?? 500);
-$allowedCodes = [403, 404, 500, 503];
+$allowedCodes = [401, 403, 404, 500, 503];
 if (!in_array($code, $allowedCodes, true)) {
     $code = 500;
 }

--- a/public/fetch_upload.php
+++ b/public/fetch_upload.php
@@ -10,8 +10,8 @@ $relativePath = $_GET['file'] ?? '';
 // Basisverzeichnis bestimmen
 $basePath = realpath(__DIR__ . '/../uploads');
 if ($basePath === false) {
-    http_response_code(500);
-    exit('Upload-Verzeichnis fehlt.');
+    $reason = 'Upload-Verzeichnis fehlt.';
+    handle_error(500, $reason);
 }
 
 // Zielpfad auflösen und sicherstellen, dass er im Upload-Verzeichnis liegt
@@ -22,8 +22,8 @@ if (
     strpos($targetPath, $basePath) !== 0 ||
     !is_file($targetPath)
 ) {
-    http_response_code(404);
-    exit('Datei nicht gefunden.');
+    $reason = 'Datei nicht gefunden.';
+    handle_error(404, $reason);
 }
 
 // Content-Type anhand von MIME ermitteln

--- a/public/groups.php
+++ b/public/groups.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../includes/config.inc.php';
 // Login-Schutz
 if (empty($_SESSION['user_id']) || empty($_SESSION['username'])) {
     $reason = "Du musst eingeloggt sein, um deine Gruppen zu sehen.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 if (empty($_SESSION['csrf_token'])) {

--- a/public/gruppe.php
+++ b/public/gruppe.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../includes/config.inc.php';
 
 if (empty($_SESSION['user_id'])) {
     $reason = "Du musst eingeloggt sein, um Dateien hochladen zu können.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 if (empty($_SESSION['csrf_token'])) {
@@ -27,9 +27,8 @@ $success = '';
 // Gruppe laden
 $group = DbFunctions::fetchGroupById($groupId);
 if (!$group) {
-    http_response_code(404);
-    echo 'Gruppe nicht gefunden';
-    exit;
+    $reason = 'Gruppe nicht gefunden';
+    handle_error(404, $reason);
 }
 
 // Rolle des Users (admin/member/none)

--- a/public/join_group.php
+++ b/public/join_group.php
@@ -6,7 +6,7 @@ $log = LoggerFactory::get('join_group');
 
 if (empty($_SESSION['user_id'])) {
     $reason = 'Du musst eingeloggt sein, um einer Gruppe beizutreten.';
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 $token = trim((string)($_GET['token'] ?? ''));

--- a/public/locked_users.php
+++ b/public/locked_users.php
@@ -6,9 +6,13 @@ require_once __DIR__ . '/../includes/config.inc.php';
 require_once __DIR__ . '/../includes/mailing.inc.php';
 
 // Zugriff nur für Admins oder Moderatoren
-if (empty($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', ['admin', 'mod'], true)) {
-    http_response_code(403);
-    exit('Zugriff verweigert.');
+if (empty($_SESSION['user_id'])) {
+    $reason = 'Nicht eingeloggt.';
+    handle_error(401, $reason, 'both');
+}
+if (!in_array($_SESSION['role'] ?? '', ['admin', 'mod'], true)) {
+    $reason = 'Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen.';
+    handle_error(403, $reason, 'both');
 }
 
 // Benutzer entsperren + Mail versenden

--- a/public/my_groups.php
+++ b/public/my_groups.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../includes/config.inc.php';
 // Zugriffsschutz: Nur für eingeloggte Nutzer
 if (empty($_SESSION['user_id'])) {
     $reason = "Du musst eingeloggt sein, um Lerngruppen nutzen zu können.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 $userId  = (int)$_SESSION['user_id'];

--- a/public/my_uploads.php
+++ b/public/my_uploads.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../includes/config.inc.php';
 // Zugriffsschutz
 if (empty($_SESSION['user_id'])) {
     $reason = "Du musst eingeloggt sein, um deine Uploads zu sehen.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 $userId = (int)$_SESSION['user_id'];

--- a/public/passwort_change.php
+++ b/public/passwort_change.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../src/PasswordController.php';
 
 if (empty($_SESSION['user_id'])) {
     $reason = 'Du musst eingeloggt sein, um dein Passwort zu ändern.';
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 $success = false;

--- a/public/pending_courses.php
+++ b/public/pending_courses.php
@@ -5,9 +5,13 @@ session_start();
 require_once __DIR__ . '/../includes/config.inc.php';
 require_once __DIR__ . '/../includes/mailing.inc.php';
 
-if (empty($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', ['admin', 'mod'], true)) {
-    http_response_code(403);
-    exit('Zugriff verweigert.');
+if (empty($_SESSION['user_id'])) {
+    $reason = 'Nicht eingeloggt.';
+    handle_error(401, $reason, 'both');
+}
+if (!in_array($_SESSION['role'] ?? '', ['admin', 'mod'], true)) {
+    $reason = 'Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen.';
+    handle_error(403, $reason, 'both');
 }
 
 $filters = [

--- a/public/pending_uploads.php
+++ b/public/pending_uploads.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 require_once __DIR__ . '/../includes/config.inc.php';
 session_start();
 
+if (empty($_SESSION['user_id'])) {
+    $reason = 'Nicht eingeloggt.';
+    handle_error(401, $reason, 'both');
+}
+
 $isAdmin = ($_SESSION['role'] ?? '') === 'admin';
 $isMod   = ($_SESSION['role'] ?? '') === 'mod';
 
 if (!$isAdmin && !$isMod) {
-    http_response_code(403);
-    exit('Zugriff verweigert.');
+    $reason = 'Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen.';
+    handle_error(403, $reason, 'both');
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/public/profile.php
+++ b/public/profile.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../src/PasswordController.php';
 // Login-Schutz
 if (empty($_SESSION['user_id']) || empty($_SESSION['username'])) {
     $reason = "Du musst eingeloggt sein, um dein Profil zu sehen.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 $userId   = $_SESSION['user_id'];

--- a/public/saveprofile.php
+++ b/public/saveprofile.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/../includes/config.inc.php';
 
 if (empty($_SESSION['user_id'])) {
-    http_response_code(403);
-    exit('Nicht eingeloggt.');
+    $reason = 'Nicht eingeloggt.';
+    handle_error(401, $reason, 'both');
 }
 
 $userId = $_SESSION['user_id'];

--- a/public/search_profile.php
+++ b/public/search_profile.php
@@ -1,9 +1,10 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__ . '/../includes/config.inc.php';
+
 if (empty($_SESSION['user_id'])) {
-    http_response_code(403);
-    exit('Nicht eingeloggt.');
+    $reason = 'Nicht eingeloggt.';
+    handle_error(401, $reason, 'both');
 }
 
 $searchTerm = $_GET['q'] ?? '';

--- a/public/timetable.php
+++ b/public/timetable.php
@@ -12,7 +12,7 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 // Prüfen, ob Nutzer eingeloggt ist
 if (empty($_SESSION['user_id']) || empty($_SESSION['username'])) {
     $reason = "Du musst eingeloggt sein, um dein Stundenplan zu sehen.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 $userId = (int) $_SESSION['user_id'];

--- a/public/todos.php
+++ b/public/todos.php
@@ -11,7 +11,7 @@ if (!isset($_SESSION['just_completed'])) {
 // Sicherstellen, dass der Benutzer eingeloggt ist
 if (empty($_SESSION['user_id'])) {
     $reason = "Du musst eingeloggt sein, um ToDos zu erstellen.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 $userId   = (int)$_SESSION['user_id'];

--- a/public/update_profile.php
+++ b/public/update_profile.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/../includes/config.inc.php';
 
 if (empty($_SESSION['user_id'])) {
-    http_response_code(403);
-    exit('Nicht eingeloggt.');
+    $reason = 'Nicht eingeloggt.';
+    handle_error(401, $reason, 'both');
 }
 
 $userId = (int)$_SESSION['user_id'];

--- a/public/upload.php
+++ b/public/upload.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../includes/pdf_utils.inc.php';
 
 if (empty($_SESSION['user_id'])) {
     $reason = "Du musst eingeloggt sein, um Dateien hochladen zu können.";
-    handle_error(403, $reason, 'both');
+    handle_error(401, $reason, 'both');
 }
 
 if (empty($_SESSION['csrf_token'])) {

--- a/public/upload_logs.php
+++ b/public/upload_logs.php
@@ -10,9 +10,13 @@ register_shutdown_function(function () {
 
 require_once __DIR__ . '/../includes/config.inc.php';
 
-if (empty($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', ['admin', 'mod'], true)) {
-    http_response_code(403);
-    exit('Zugriff verweigert.');
+if (empty($_SESSION['user_id'])) {
+    $reason = 'Nicht eingeloggt.';
+    handle_error(401, $reason, 'both');
+}
+if (!in_array($_SESSION['role'] ?? '', ['admin', 'mod'], true)) {
+    $reason = 'Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen.';
+    handle_error(403, $reason, 'both');
 }
 
 $role = $_SESSION['role'] ?? '';

--- a/public/view_pdf.php
+++ b/public/view_pdf.php
@@ -5,8 +5,8 @@ $filename = basename($_GET['file'] ?? '');
 $path = __DIR__ . '/../uploads/' . $filename;
 
 if (!preg_match('/\.pdf$/i', $filename) || !file_exists($path)) {
-    http_response_code(404);
-    exit('Datei nicht gefunden.');
+    $reason = 'Datei nicht gefunden.';
+    handle_error(404, $reason);
 }
 
 header('Content-Type: application/pdf');

--- a/templates/errors/401.tpl
+++ b/templates/errors/401.tpl
@@ -1,0 +1,29 @@
+{extends file="../layouts/layout.tpl"}
+
+{block name="title"}401 – Anmeldung erforderlich{/block}
+
+{block name="content"}
+    <div class="text-center py-5">
+        <img src="{$base_url}/assets/403.png" alt="401 Fehlerroboter" class="mb-4" style="max-width: 320px;">
+        <h1 class="display-4 text-danger">401 – Anmeldung erforderlich</h1>
+        <p class="lead">{$reason|default:"Du musst eingeloggt sein, um diese Seite aufzurufen."}</p>
+
+{if $action == 'login' || $action == 'register' || $action == 'both'}
+    <div class="d-flex justify-content-center align-items-center gap-3 mt-4 flex-wrap">
+        {if $action == 'login' || $action == 'both'}
+            <a href="{$base_url}/?show=login" class="btn btn-primary">Jetzt einloggen</a>
+        {/if}
+
+        {if $action == 'both'}
+            <span class="fw-semibold text-muted">oder</span>
+        {/if}
+
+        {if $action == 'register' || $action == 'both'}
+            <a href="{$base_url}/?show=register" class="btn btn-outline-secondary">Account erstellen</a>
+        {/if}
+    </div>
+{/if}
+
+        <a href="{$base_url}/" class="btn btn-link d-block mt-3">Zur Startseite</a>
+    </div>
+{/block}

--- a/templates/errors/403.tpl
+++ b/templates/errors/403.tpl
@@ -1,32 +1,13 @@
 {* templates/errors/403.tpl *}
 {extends file="../layouts/layout.tpl"}
 
-{block name="title"}403 – Zugriff verweigert{/block}
+{block name="title"}403 – Keine ausreichenden Rechte{/block}
 
 {block name="content"}
     <div class="text-center py-5">
         <img src="{$base_url}/assets/403.png" alt="403 Fehlerroboter" class="mb-4" style="max-width: 320px;">
-        <h1 class="display-4 text-danger">403 – Zugriff verweigert</h1>
-        <p class="lead">{$reason|default:"Du hast keine Berechtigung, diese Seite aufzurufen."}</p>
-
-{if $action == 'login' || $action == 'register' || $action == 'both'}
-    <div class="d-flex justify-content-center align-items-center gap-3 mt-4 flex-wrap">
-        {if $action == 'login' || $action == 'both'}
-            <a href="{$base_url}/?show=login" class="btn btn-primary">Jetzt einloggen</a>
-        {/if}
-
-        {if $action == 'both'}
-            <span class="fw-semibold text-muted">oder</span>
-        {/if}
-
-        {if $action == 'register' || $action == 'both'}
-            <a href="{$base_url}/?show=register" class="btn btn-outline-secondary">Account erstellen</a>
-        {/if}
-    </div>
-{/if}
-
-
-
+        <h1 class="display-4 text-danger">403 – Keine ausreichenden Rechte</h1>
+        <p class="lead">{$reason|default:"Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen."}</p>
         <a href="{$base_url}/" class="btn btn-link d-block mt-3">Zur Startseite</a>
     </div>
 {/block}


### PR DESCRIPTION
## Summary
- use `handle_error()` in scripts that previously set status codes directly
- show clearer message on 403 pages
- 403 page now only displays a button back to the homepage

## Testing
- `php -v` *(fails: php not installed)*
- `php -l public/delete_upload.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b860c1e688332a439c530eed49753