### PR TITLE
Update group event permissions and translations

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -300,6 +300,18 @@ class DbFunctions
     }
 
     /**
+     * Löscht einen Gruppentermin.
+     */
+    public static function deleteGroupEvent(int $eventId, int $groupId): bool
+    {
+        $sql = 'DELETE FROM group_events WHERE id = :eid AND group_id = :gid';
+        return self::execute($sql, [
+            ':eid' => $eventId,
+            ':gid' => $groupId,
+        ]) > 0;
+    }
+
+    /**
      * Liefert alle Termine einer Gruppe.
      */
     public static function getGroupEventsByGroup(int $groupId): array

--- a/templates/gruppe.tpl
+++ b/templates/gruppe.tpl
@@ -29,10 +29,16 @@
             <div class="text-muted small">
               {$ev.event_date|date_format:"%d.%m.%Y"}
               {if $ev.repeat_interval !== 'none'}
-                &middot; {$ev.repeat_interval|escape}
+                &middot; {$ev.repeat_label|escape}
               {/if}
             </div>
           </span>
+          {if $myRole === 'admin'}
+            <form method="post" class="ms-2" onsubmit="return confirm('Termin wirklich löschen?');">
+              <input type="hidden" name="event_id" value="{$ev.id}">
+              <button type="submit" name="delete_event" class="btn btn-sm btn-outline-danger">Löschen</button>
+            </form>
+          {/if}
         </li>
       {/foreach}
     </ul>
@@ -40,7 +46,7 @@
     <p class="text-muted">Keine Termine vorhanden.</p>
   {/if}
 
-  {if $myRole !== 'none'}
+  {if $myRole === 'admin'}
     <h4>Neuen Termin erstellen</h4>
     <form method="post" class="mb-4">
       <div class="row g-2">


### PR DESCRIPTION
## Summary
- allow group admins to delete events
- restrict event creation to admins
- display repeat interval labels in German

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfbf3d4008332bfa79455873d462b