### PR TITLE
Fix logo navigation when logged in

### DIFF
--- a/templates/layouts/layout.tpl
+++ b/templates/layouts/layout.tpl
@@ -24,7 +24,7 @@
 
 <header class="site-header d-flex justify-content-between align-items-center px-4 py-2">
   <div class="header-logo">
-    <a href="{$base_url}/">
+    <a href="{if $isLoggedIn}{url path='dashboard'}{else}{url}{/if}">
       <img src="{$base_url}/assets/logo.svg" alt="StudyHub Logo" width="160">
     </a>
   </div>


### PR DESCRIPTION
## Summary
- fix the logo link so logged-in users go to the dashboard

## Testing
- `composer validate --no-check-publish` *(fails: composer not found)*
- `php -v` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcb65f8ac83328402d33e9b4a7fda