### PR TITLE
Ensure single session start

### DIFF
--- a/public/contact.php
+++ b/public/contact.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-session_start();
+// Session wird bereits in config.inc.php gestartet
 
 require_once __DIR__ . '/../includes/config.inc.php';
 

--- a/public/locked_users.php
+++ b/public/locked_users.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-session_start();
+// Session wird bereits in config.inc.php gestartet
 
 require_once __DIR__ . '/../includes/config.inc.php';
 require_once __DIR__ . '/../includes/mailing.inc.php';

--- a/public/passwort_change.php
+++ b/public/passwort_change.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-session_start();
+// Session wird bereits in config.inc.php gestartet
 header('Content-Type: text/html; charset=utf-8');
 
 require_once __DIR__ . '/../includes/config.inc.php';

--- a/public/pending_courses.php
+++ b/public/pending_courses.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-session_start();
+// Session wird bereits in config.inc.php gestartet
 
 require_once __DIR__ . '/../includes/config.inc.php';
 require_once __DIR__ . '/../includes/mailing.inc.php';

--- a/public/rate_material.php
+++ b/public/rate_material.php
@@ -5,7 +5,7 @@ ini_set('display_startup_errors', '1');
 error_reporting(E_ALL);
 
 require_once __DIR__ . '/../includes/config.inc.php';
-session_start();
+// Session wird bereits in config.inc.php gestartet
 
 // Sicherstellen, dass der Benutzer eingeloggt ist
 if (empty($_SESSION['user_id'])) {

--- a/public/router.php
+++ b/public/router.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-session_start();
+// Session wird bereits in config.inc.php gestartet
 
 require_once __DIR__ . '/../includes/config.inc.php';
 

--- a/public/timetable.php
+++ b/public/timetable.php
@@ -5,9 +5,7 @@ error_reporting(E_ALL);
 
 require_once __DIR__ . '/../includes/config.inc.php';
 
-if (session_status() !== PHP_SESSION_ACTIVE) {
-    session_start();
-}
+// Session wird bereits in config.inc.php gestartet
 
 // Prüfen, ob Nutzer eingeloggt ist
 if (empty($_SESSION['user_id']) || empty($_SESSION['username'])) {

--- a/public/upload_logs.php
+++ b/public/upload_logs.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-session_start();
+// Session wird bereits in config.inc.php gestartet
 register_shutdown_function(function () {
     $err = error_get_last();
     if ($err) {


### PR DESCRIPTION
## Summary
- avoid starting sessions in multiple places
- rely on `config.inc.php` for starting the session

## Testing
- `php -l public/upload_logs.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863ae1557308332b768a66bf902499d