### PR TITLE
Fix registration AJAX path

### DIFF
--- a/public/js/register.js
+++ b/public/js/register.js
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
       grecaptcha.execute(siteKey, { action: 'register' }).then(async token => {
         tokenField.value = token;
         try {
-          const response = await fetch('register.php', {
+          const response = await fetch(baseUrl + '/register.php', {
             method: 'POST',
             body: new FormData(registerForm)
           });


### PR DESCRIPTION
## Summary
- ensure registration fetch uses absolute URL

## Testing
- `node --check public/js/register.js`


------
https://chatgpt.com/codex/tasks/task_e_6863ca53f060833292aaae6d451293be