### PR TITLE
Fix XSS vector in error pages

### DIFF
--- a/templates/errors/401.tpl
+++ b/templates/errors/401.tpl
@@ -6,7 +6,7 @@
     <div class="text-center py-5">
         <img src="{$base_url}/assets/401.png" alt="401 Fehlerroboter" class="mb-4" style="max-width: 320px;">
         <h1 class="display-4 text-danger">401 – Anmeldung erforderlich</h1>
-        <p class="lead">{$reason|default:"Du musst eingeloggt sein, um diese Seite aufzurufen."}</p>
+        <p class="lead">{$reason|default:"Du musst eingeloggt sein, um diese Seite aufzurufen."|escape}</p>
 
 {if $action == 'login' || $action == 'register' || $action == 'both'}
     <div class="d-flex justify-content-center align-items-center gap-3 mt-4 flex-wrap">

--- a/templates/errors/403.tpl
+++ b/templates/errors/403.tpl
@@ -7,7 +7,7 @@
     <div class="text-center py-5">
         <img src="{$base_url}/assets/403.png" alt="403 Fehlerroboter" class="mb-4" style="max-width: 320px;">
         <h1 class="display-4 text-danger">403 – Keine ausreichenden Rechte</h1>
-        <p class="lead">{$reason|default:"Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen."}</p>
+        <p class="lead">{$reason|default:"Du hast nicht die nötigen Rechte, um auf diese Ressource zuzugreifen."|escape}</p>
         <a href="{$base_url}/" class="btn btn-link d-block mt-3">Zur Startseite</a>
     </div>
 {/block}

--- a/templates/errors/404.tpl
+++ b/templates/errors/404.tpl
@@ -6,7 +6,7 @@
     <div class="text-center py-5">
         <img src="{$base_url}/assets/404.png" alt="404 Roboter" class="mb-4" style="max-width: 320px;">
         <h1 class="display-4 text-warning">404 – Seite nicht gefunden</h1>
-        <p class="lead">{$reason|default:"Die angeforderte Seite konnte nicht gefunden werden."}</p>
+        <p class="lead">{$reason|default:"Die angeforderte Seite konnte nicht gefunden werden."|escape}</p>
         <a href="{$base_url}/" class="btn btn-primary mt-4">Zur Startseite</a>
     </div>
 {/block}

--- a/templates/errors/500.tpl
+++ b/templates/errors/500.tpl
@@ -6,7 +6,7 @@
     <div class="text-center py-5">
         <img src="{$base_url}/assets/500.png" alt="500 Roboter" class="mb-4" style="max-width: 320px;">
         <h1 class="display-4 text-danger">500 – Interner Serverfehler</h1>
-        <p class="lead">{$reason|default:"Etwas ist schiefgelaufen. Bitte versuche es später erneut."}</p>
+        <p class="lead">{$reason|default:"Etwas ist schiefgelaufen. Bitte versuche es später erneut."|escape}</p>
         <a href="{$base_url}/" class="btn btn-primary mt-4">Zur Startseite</a>
     </div>
 {/block}

--- a/templates/errors/503.tpl
+++ b/templates/errors/503.tpl
@@ -6,7 +6,7 @@
     <div class="text-center py-5">
         <img src="{$base_url}/assets/503.png" alt="503 Roboter" class="mb-4" style="max-width: 320px;">
         <h1 class="display-4 text-secondary">503 – Service nicht verfügbar</h1>
-        <p class="lead">{$reason|default:"Der Dienst ist vorübergehend nicht erreichbar. Bitte versuche es später erneut."}</p>
+        <p class="lead">{$reason|default:"Der Dienst ist vorübergehend nicht erreichbar. Bitte versuche es später erneut."|escape}</p>
         <a href="{$base_url}/" class="btn btn-primary mt-4">Zur Startseite</a>
     </div>
 {/block}


### PR DESCRIPTION
## Summary
- escape the `reason` parameter in all error templates

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6863f13f5b688332a3f761a3a43fdf78