### PR TITLE
fix: safeguard is_group_event access in calendar template

### DIFF
--- a/templates/partials/calendar_month.tpl
+++ b/templates/partials/calendar_month.tpl
@@ -25,7 +25,7 @@
           <div class="col calendar-cell{if $day.is_today} calendar-today{/if}">
             <span class="calendar-date">{$day.day}</span>
             {foreach $day.tasks as $task}
-              {if $task.is_group_event}
+              {if $task.is_group_event|default:false}
                 <div class="calendar-task calendar-group-event">
                   <img src="{if $task.group_picture}{url file="group_pictures/{$task.group_picture|escape:'url'}"}{else}{$base_url}/assets/default_group.png{/if}"
                        alt="Gruppenbild" style="width:16px;height:16px;object-fit:cover;border-radius:50%;">

--- a/templates/partials/today_tasks.tpl
+++ b/templates/partials/today_tasks.tpl
@@ -3,7 +3,7 @@
   {if $todayTodos|@count > 0}
     <ul class="list-group">
       {foreach $todayTodos as $task}
-        {if $task.is_group_event}
+        {if $task.is_group_event|default:false}
           <li class="list-group-item list-group-item-info d-flex align-items-center">
             <img src="{if $task.group_picture}{url file="group_pictures/{$task.group_picture|escape:'url'}"}{else}{$base_url}/assets/default_group.png{/if}"
                  alt="Gruppenbild" class="me-1 rounded-circle" style="width:24px;height:24px;object-fit:cover;">


### PR DESCRIPTION
## Summary
- prevent PHP warnings when `is_group_event` is missing
- update calendar month and today task templates

## Testing
- `php -l templates/calendar_month.tpl.php` *(fails: Could not open input file)*
- `php -l templates/partials/calendar_month.tpl`
- `php -l templates/partials/today_tasks.tpl`


------
https://chatgpt.com/codex/tasks/task_e_6864077f9fd48332914403c0432e9958