### PR TITLE
Ensure unique username and email on profile edit

### DIFF
--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -2574,6 +2574,34 @@ public static function getFilteredLockedUsers(array $filters = []): array
     }
 
     /**
+     * Prüft, ob ein Benutzername bereits vergeben ist.
+     */
+    public static function usernameExists(string $username, ?int $excludeId = null): bool
+    {
+        $sql = 'SELECT id FROM users WHERE username = :u';
+        $params = [':u' => $username];
+        if ($excludeId !== null) {
+            $sql .= ' AND id != :id';
+            $params[':id'] = $excludeId;
+        }
+        return (bool) self::fetchValue($sql, $params);
+    }
+
+    /**
+     * Prüft, ob eine E-Mail-Adresse bereits vergeben ist.
+     */
+    public static function emailExists(string $email, ?int $excludeId = null): bool
+    {
+        $sql = 'SELECT id FROM users WHERE email = :e';
+        $params = [':e' => $email];
+        if ($excludeId !== null) {
+            $sql .= ' AND id != :id';
+            $params[':id'] = $excludeId;
+        }
+        return (bool) self::fetchValue($sql, $params);
+    }
+
+    /**
      * Löscht alle Einträge im Stundenplan eines Nutzers.
      */
     public static function deleteAllTimetableEntries(int $userId): void

--- a/public/saveprofile.php
+++ b/public/saveprofile.php
@@ -47,9 +47,13 @@ if ($newEmail !== '' && $newEmail !== $currentEmail) {
     if (!filter_var($newEmail, FILTER_VALIDATE_EMAIL)) {
         exit('Ungültige E-Mail-Adresse.');
     }
-    $count = DbFunctions::countWhere('users', 'email', $newEmail);
-    if ($count > 0) {
-        exit('E-Mail-Adresse wird bereits verwendet.');
+    if (DbFunctions::emailExists($newEmail, (int)$userId)) {
+        $_SESSION['flash'] = [
+            'type'    => 'danger',
+            'message' => 'E-Mail-Adresse wird bereits verwendet.'
+        ];
+        header('Location: edit_profile');
+        exit;
     }
     DbFunctions::updateEmail($userId, $newEmail);
     DbFunctions::unverifyUser($userId);

--- a/public/update_profile.php
+++ b/public/update_profile.php
@@ -19,7 +19,7 @@ try {
             if ($username === '') {
                 throw new RuntimeException('Ungültiger Benutzername.');
             }
-            if (DbFunctions::countWhere('users', 'username', $username) > 0) {
+            if (DbFunctions::usernameExists($username, $userId)) {
                 throw new RuntimeException('Benutzername bereits vergeben.');
             }
             DbFunctions::execute('UPDATE users SET username = :u WHERE id = :id', [
@@ -35,7 +35,7 @@ try {
             if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
                 throw new RuntimeException('Ungültige E-Mail-Adresse.');
             }
-            if (DbFunctions::countWhere('users', 'email', $email) > 0) {
+            if (DbFunctions::emailExists($email, $userId)) {
                 throw new RuntimeException('E-Mail-Adresse wird bereits verwendet.');
             }
             DbFunctions::updateEmail($userId, $email);


### PR DESCRIPTION
## Summary
- add `usernameExists` and `emailExists` helpers in `DbFunctions`
- use the helpers when updating username or email
- show an alert in `saveprofile.php` if the new email already exists

## Testing
- `composer validate --no-check-all`
- `php -l includes/db.inc.php`
- `php -l public/update_profile.php`
- `php -l public/saveprofile.php`
- `find public includes src -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_686413af2fa48332bc6940c2cd9153e2