### PR TITLE
Enforce password rules on profile update

### DIFF
--- a/includes/config.inc.php
+++ b/includes/config.inc.php
@@ -30,6 +30,7 @@ require_once __DIR__ . '/../includes/recaptcha.inc.php';
 require_once __DIR__ . '/../includes/mailing.inc.php';
 require_once __DIR__ . '/../includes/group_invites.inc.php';
 require_once __DIR__ . '/../includes/crypto.inc.php';
+require_once __DIR__ . '/../includes/password_requirements.inc.php';
 
 // .env laden
 $dotenv = Dotenv::createImmutable(__DIR__ . '/../');

--- a/includes/password_requirements.inc.php
+++ b/includes/password_requirements.inc.php
@@ -1,0 +1,9 @@
+<?php
+function password_meets_requirements(string $password): bool {
+    $lengthOk = preg_match('/^.{8,128}$/', $password) === 1;
+    $hasNumber = preg_match('/[0-9]/', $password) === 1;
+    $hasLower  = preg_match('/[a-z]/', $password) === 1;
+    $hasUpper  = preg_match('/[A-Z]/', $password) === 1;
+    $hasSpecial= preg_match('/[^A-Za-z0-9]/', $password) === 1;
+    return $lengthOk && $hasNumber && $hasLower && $hasUpper && $hasSpecial;
+}

--- a/public/js/password-requirements.js
+++ b/public/js/password-requirements.js
@@ -25,6 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const ok = requirements[li.dataset.requirement].regex.test(val);
         li.classList.toggle('valid', ok);
         li.classList.toggle('invalid', !ok);
+        const icon = li.querySelector('i');
+        if (icon) icon.textContent = ok ? 'check' : 'close';
       });
     });
 

--- a/public/js/password-requirements.js
+++ b/public/js/password-requirements.js
@@ -1,0 +1,51 @@
+// password-requirements.js
+// Handles password requirement checks for forms with data-pw-validate
+
+document.addEventListener('DOMContentLoaded', () => {
+  const requirements = {
+    minlength: { regex: /.{8,}/,       message: 'Mindestens 8 Zeichen' },
+    maxlength: { regex: /^.{0,128}$/,  message: 'Maximal 128 Zeichen' },
+    number:    { regex: /[0-9]/,       message: 'Mindestens eine Zahl' },
+    lowercase: { regex: /[a-z]/,       message: 'Mindestens einen Kleinbuchstaben' },
+    uppercase: { regex: /[A-Z]/,       message: 'Mindestens einen Großbuchstaben' },
+    special:   { regex: /[^A-Za-z0-9]/,message: 'Mindestens ein Sonderzeichen' },
+  };
+
+  document.querySelectorAll('form[data-pw-validate]').forEach(form => {
+    const pwdInput = form.querySelector('.pw-new');
+    const confirmInput = form.querySelector('.pw-confirm');
+    const reqList = form.querySelector('.requirement-list');
+    if (!pwdInput || !confirmInput || !reqList) return;
+
+    pwdInput.addEventListener('focus', () => reqList.classList.add('visible'));
+    pwdInput.addEventListener('blur', () => reqList.classList.remove('visible'));
+    pwdInput.addEventListener('input', () => {
+      const val = pwdInput.value;
+      reqList.querySelectorAll('li').forEach(li => {
+        const ok = requirements[li.dataset.requirement].regex.test(val);
+        li.classList.toggle('valid', ok);
+        li.classList.toggle('invalid', !ok);
+      });
+    });
+
+    form.addEventListener('submit', e => {
+      pwdInput.setCustomValidity('');
+      confirmInput.setCustomValidity('');
+
+      const pwErrors = [];
+      Object.values(requirements).forEach(({ regex, message }) => {
+        if (!regex.test(pwdInput.value)) pwErrors.push(message);
+      });
+      if (pwErrors.length) {
+        pwdInput.setCustomValidity(pwErrors.join('\n'));
+      }
+      if (pwdInput.value !== confirmInput.value) {
+        confirmInput.setCustomValidity('Passwörter stimmen nicht überein.');
+      }
+      if (!form.checkValidity()) {
+        e.preventDefault();
+        form.reportValidity();
+      }
+    });
+  });
+});

--- a/public/update_profile.php
+++ b/public/update_profile.php
@@ -56,12 +56,8 @@ try {
             if ($new !== $confirm) {
                 throw new RuntimeException('Passwörter stimmen nicht überein.');
             }
+            PasswordController::changePassword($userId, $old, $new);
             $user = DbFunctions::fetchUserById($userId);
-            if (!$user || !verifyPassword($old, $user['password_hash'])) {
-                throw new RuntimeException('Aktuelles Passwort falsch.');
-            }
-            $hash = password_hash($new, PASSWORD_DEFAULT);
-            DbFunctions::updatePassword($userId, $hash);
 
             // Confirmation email
             try {

--- a/src/PasswordController.php
+++ b/src/PasswordController.php
@@ -34,6 +34,9 @@ class PasswordController
         if (!$user || !verifyPassword($oldPassword, $user['password_hash'])) {
             throw new RuntimeException('Aktuelles Passwort falsch');
         }
+        if (!password_meets_requirements($newPassword)) {
+            throw new RuntimeException('Passwort erfüllt nicht die Bedingungen');
+        }
         $hash = password_hash($newPassword, PASSWORD_DEFAULT);
         DbFunctions::updatePassword($userId, $hash);
     }

--- a/src/PasswordController.php
+++ b/src/PasswordController.php
@@ -22,6 +22,9 @@ class PasswordController
         if (!$user) {
             throw new RuntimeException('Token ungültig oder abgelaufen');
         }
+        if (!password_meets_requirements($password)) {
+            throw new RuntimeException('Passwort erfüllt nicht die Bedingungen');
+        }
         $hash = password_hash($password, PASSWORD_DEFAULT);
         DbFunctions::updatePassword((int)$user['id'], $hash);
         DbFunctions::deletePasswordResetToken((int)$user['id']);

--- a/templates/layouts/layout.tpl
+++ b/templates/layouts/layout.tpl
@@ -124,6 +124,7 @@
 <script src="{$base_url}/js/login-success.js"></script>
 <script src="{$base_url}/js/theme-toggle.js"></script>
 <script src="{$base_url}/js/register.js"></script>
+<script src="{$base_url}/js/password-requirements.js"></script>
 
 {block name="scripts"}{/block}
 

--- a/templates/partials/modals.tpl
+++ b/templates/partials/modals.tpl
@@ -53,7 +53,7 @@
       <div class="modal-body">
         <div id="registerAlert" class="alert alert-danger d-none" role="alert" aria-live="assertive"></div>
 
-        <form id="registerForm" method="POST" action="{url path='register'}" novalidate>
+        <form id="registerForm" method="POST" action="{url path='register'}" data-pw-validate novalidate>
           <div class="mb-3">
             <label for="username" class="form-label">Username</label>
             <input type="text" class="form-control" id="username" name="username" required>
@@ -67,7 +67,7 @@
           <div class="mb-3 pass-field">
             <label for="password" class="form-label">Passwort</label>
             <div class="input-group">
-              <input type="password" class="form-control" id="password" name="password" required>
+              <input type="password" class="form-control pw-new" id="password" name="password" required>
               <span class="input-group-text" id="togglePassword" style="cursor: pointer;">
                 <span class="material-symbols-outlined">visibility</span>
               </span>
@@ -85,7 +85,7 @@
           <div class="mb-3 pass-field">
             <label for="password_confirm" class="form-label">Passwort bestätigen</label>
             <div class="input-group">
-              <input type="password" class="form-control" id="password_confirm" name="password_confirm" required>
+                <input type="password" class="form-control pw-confirm" id="password_confirm" name="password_confirm" required>
               <span class="input-group-text" id="togglePasswordConfirm" style="cursor: pointer;">
                 <span class="material-symbols-outlined">visibility</span>
               </span>

--- a/templates/partials/modals.tpl
+++ b/templates/partials/modals.tpl
@@ -156,4 +156,19 @@
       togglePasswordVisibility('new_password_confirm', 'toggleNewPasswordConfirm');
     });
   }
+
+  // Event Listener für Passwort-Reset Felder
+  const resetToggle = document.getElementById('toggleResetPassword');
+  if (resetToggle) {
+    resetToggle.addEventListener('click', () => {
+      togglePasswordVisibility('password', 'toggleResetPassword');
+    });
+  }
+
+  const resetConfirmToggle = document.getElementById('toggleResetPasswordConfirm');
+  if (resetConfirmToggle) {
+    resetConfirmToggle.addEventListener('click', () => {
+      togglePasswordVisibility('password_confirm', 'toggleResetPasswordConfirm');
+    });
+  }
 </script>

--- a/templates/partials/modals.tpl
+++ b/templates/partials/modals.tpl
@@ -120,17 +120,40 @@
   }
 
   // Event Listener für das Umschalten der Passwortsichtbarkeit im Login Modal
-  document.getElementById('toggleLoginPassword').addEventListener('click', function() {
-    togglePasswordVisibility('loginPassword', 'toggleLoginPassword');
-  });
+  const loginToggle = document.getElementById('toggleLoginPassword');
+  if (loginToggle) {
+    loginToggle.addEventListener('click', () => {
+      togglePasswordVisibility('loginPassword', 'toggleLoginPassword');
+    });
+  }
 
-  // Event Listener für das Umschalten der Passwortsichtbarkeit im Registration Modal
-  document.getElementById('togglePassword').addEventListener('click', function() {
-    togglePasswordVisibility('password', 'togglePassword');
-  });
+  // Event Listener für die Registrierungspasswörter
+  const regToggle = document.getElementById('togglePassword');
+  if (regToggle) {
+    regToggle.addEventListener('click', () => {
+      togglePasswordVisibility('password', 'togglePassword');
+    });
+  }
 
-  // Event Listener für das Umschalten der Passwortsichtbarkeit im Confirm Password Feld
-  document.getElementById('togglePasswordConfirm').addEventListener('click', function() {
-    togglePasswordVisibility('password_confirm', 'togglePasswordConfirm');
-  });
+  const regConfirmToggle = document.getElementById('togglePasswordConfirm');
+  if (regConfirmToggle) {
+    regConfirmToggle.addEventListener('click', () => {
+      togglePasswordVisibility('password_confirm', 'togglePasswordConfirm');
+    });
+  }
+
+  // Event Listener für Passwortänderungen (Profil/Seite)
+  const newPwToggle = document.getElementById('toggleNewPassword');
+  if (newPwToggle) {
+    newPwToggle.addEventListener('click', () => {
+      togglePasswordVisibility('new_password', 'toggleNewPassword');
+    });
+  }
+
+  const newPwConfirmToggle = document.getElementById('toggleNewPasswordConfirm');
+  if (newPwConfirmToggle) {
+    newPwConfirmToggle.addEventListener('click', () => {
+      togglePasswordVisibility('new_password_confirm', 'toggleNewPasswordConfirm');
+    });
+  }
 </script>

--- a/templates/partials/modals.tpl
+++ b/templates/partials/modals.tpl
@@ -73,12 +73,12 @@
               </span>
             </div>
             <ul class="requirement-list mb-3">
-              <li data-requirement="minlength">Mindestens 8 Zeichen</li>
-              <li data-requirement="maxlength">Maximal 128 Zeichen</li>
-              <li data-requirement="number">Mindestens eine Zahl</li>
-              <li data-requirement="lowercase">Kleinbuchstabe</li>
-              <li data-requirement="uppercase">Großbuchstabe</li>
-              <li data-requirement="special">Sonderzeichen</li>
+              <li data-requirement="minlength"><i class="material-symbols-outlined">close</i>Mindestens 8 Zeichen</li>
+              <li data-requirement="maxlength"><i class="material-symbols-outlined">close</i>Maximal 128 Zeichen</li>
+              <li data-requirement="number"><i class="material-symbols-outlined">close</i>Mindestens eine Zahl</li>
+              <li data-requirement="lowercase"><i class="material-symbols-outlined">close</i>Kleinbuchstabe</li>
+              <li data-requirement="uppercase"><i class="material-symbols-outlined">close</i>Großbuchstabe</li>
+              <li data-requirement="special"><i class="material-symbols-outlined">close</i>Sonderzeichen</li>
             </ul>
           </div>
 

--- a/templates/passwort_change.tpl
+++ b/templates/passwort_change.tpl
@@ -19,12 +19,12 @@
         <label for="new_password" class="form-label">Neues Passwort</label>
         <input type="password" class="form-control pw-new" id="new_password" name="new_password" required>
         <ul class="requirement-list mb-3">
-          <li data-requirement="minlength">Mindestens 8 Zeichen</li>
-          <li data-requirement="maxlength">Maximal 128 Zeichen</li>
-          <li data-requirement="number">Mindestens eine Zahl</li>
-          <li data-requirement="lowercase">Kleinbuchstabe</li>
-          <li data-requirement="uppercase">Großbuchstabe</li>
-          <li data-requirement="special">Sonderzeichen</li>
+          <li data-requirement="minlength"><i class="material-symbols-outlined">close</i>Mindestens 8 Zeichen</li>
+          <li data-requirement="maxlength"><i class="material-symbols-outlined">close</i>Maximal 128 Zeichen</li>
+          <li data-requirement="number"><i class="material-symbols-outlined">close</i>Mindestens eine Zahl</li>
+          <li data-requirement="lowercase"><i class="material-symbols-outlined">close</i>Kleinbuchstabe</li>
+          <li data-requirement="uppercase"><i class="material-symbols-outlined">close</i>Großbuchstabe</li>
+          <li data-requirement="special"><i class="material-symbols-outlined">close</i>Sonderzeichen</li>
         </ul>
     </div>
     <div class="mb-3">

--- a/templates/passwort_change.tpl
+++ b/templates/passwort_change.tpl
@@ -10,18 +10,26 @@
     <div class="alert alert-danger">{$message}</div>
 {/if}
 <div id="formAlert" class="alert alert-danger d-none">Bitte alle Felder ausfüllen.</div>
-<form method="post" class="needs-validation" novalidate>
+<form method="post" class="needs-validation" data-pw-validate novalidate>
     <div class="mb-3">
         <label for="old_password" class="form-label">Aktuelles Passwort</label>
         <input type="password" class="form-control" id="old_password" name="old_password" required>
     </div>
-    <div class="mb-3">
+    <div class="mb-3 pass-field">
         <label for="new_password" class="form-label">Neues Passwort</label>
-        <input type="password" class="form-control" id="new_password" name="new_password" required>
+        <input type="password" class="form-control pw-new" id="new_password" name="new_password" required>
+        <ul class="requirement-list mb-3">
+          <li data-requirement="minlength">Mindestens 8 Zeichen</li>
+          <li data-requirement="maxlength">Maximal 128 Zeichen</li>
+          <li data-requirement="number">Mindestens eine Zahl</li>
+          <li data-requirement="lowercase">Kleinbuchstabe</li>
+          <li data-requirement="uppercase">Großbuchstabe</li>
+          <li data-requirement="special">Sonderzeichen</li>
+        </ul>
     </div>
     <div class="mb-3">
         <label for="new_password_confirm" class="form-label">Passwort bestätigen</label>
-        <input type="password" class="form-control" id="new_password_confirm" name="new_password_confirm" required>
+        <input type="password" class="form-control pw-confirm" id="new_password_confirm" name="new_password_confirm" required>
     </div>
     <button type="submit" class="btn btn-primary">Passwort speichern</button>
 </form>

--- a/templates/passwort_change.tpl
+++ b/templates/passwort_change.tpl
@@ -17,7 +17,12 @@
     </div>
     <div class="mb-3 pass-field">
         <label for="new_password" class="form-label">Neues Passwort</label>
-        <input type="password" class="form-control pw-new" id="new_password" name="new_password" required>
+        <div class="input-group">
+            <input type="password" class="form-control pw-new" id="new_password" name="new_password" required>
+            <span class="input-group-text" id="toggleNewPassword" style="cursor: pointer;">
+                <span class="material-symbols-outlined">visibility</span>
+            </span>
+        </div>
         <ul class="requirement-list mb-3">
           <li data-requirement="minlength"><i class="material-symbols-outlined">close</i>Mindestens 8 Zeichen</li>
           <li data-requirement="maxlength"><i class="material-symbols-outlined">close</i>Maximal 128 Zeichen</li>
@@ -29,7 +34,12 @@
     </div>
     <div class="mb-3">
         <label for="new_password_confirm" class="form-label">Passwort bestätigen</label>
-        <input type="password" class="form-control pw-confirm" id="new_password_confirm" name="new_password_confirm" required>
+        <div class="input-group">
+            <input type="password" class="form-control pw-confirm" id="new_password_confirm" name="new_password_confirm" required>
+            <span class="input-group-text" id="toggleNewPasswordConfirm" style="cursor: pointer;">
+                <span class="material-symbols-outlined">visibility</span>
+            </span>
+        </div>
     </div>
     <button type="submit" class="btn btn-primary">Passwort speichern</button>
 </form>

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -155,7 +155,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
       </div>
       <div class="modal-body">
-        <form method="post" action="{url path='update_profile'}" data-pw-validate>
+        <form method="post" action="{url path='update_profile'}">
           <input type="hidden" name="action" value="update_username">
           <div class="mb-3">
             <label for="new_username" class="form-label">Neuer Benutzername</label>
@@ -199,7 +199,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
       </div>
       <div class="modal-body">
-        <form method="post" action="{url path='update_profile'}">
+        <form method="post" action="{url path='update_profile'}" data-pw-validate>
           <input type="hidden" name="action" value="update_password">
           <div class="mb-3">
             <label for="current_password" class="form-label">Aktuelles Passwort</label>
@@ -209,12 +209,12 @@
             <label for="new_password" class="form-label">Neues Passwort</label>
             <input type="password" class="form-control pw-new" id="new_password" name="new_password" required>
             <ul class="requirement-list mb-3">
-              <li data-requirement="minlength">Mindestens 8 Zeichen</li>
-              <li data-requirement="maxlength">Maximal 128 Zeichen</li>
-              <li data-requirement="number">Mindestens eine Zahl</li>
-              <li data-requirement="lowercase">Kleinbuchstabe</li>
-              <li data-requirement="uppercase">Großbuchstabe</li>
-              <li data-requirement="special">Sonderzeichen</li>
+              <li data-requirement="minlength"><i class="material-symbols-outlined">close</i>Mindestens 8 Zeichen</li>
+              <li data-requirement="maxlength"><i class="material-symbols-outlined">close</i>Maximal 128 Zeichen</li>
+              <li data-requirement="number"><i class="material-symbols-outlined">close</i>Mindestens eine Zahl</li>
+              <li data-requirement="lowercase"><i class="material-symbols-outlined">close</i>Kleinbuchstabe</li>
+              <li data-requirement="uppercase"><i class="material-symbols-outlined">close</i>Großbuchstabe</li>
+              <li data-requirement="special"><i class="material-symbols-outlined">close</i>Sonderzeichen</li>
             </ul>
           </div>
           <div class="mb-3">

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -207,7 +207,12 @@
           </div>
           <div class="mb-3 pass-field">
             <label for="new_password" class="form-label">Neues Passwort</label>
-            <input type="password" class="form-control pw-new" id="new_password" name="new_password" required>
+            <div class="input-group">
+              <input type="password" class="form-control pw-new" id="new_password" name="new_password" required>
+              <span class="input-group-text" id="toggleNewPassword" style="cursor: pointer;">
+                <span class="material-symbols-outlined">visibility</span>
+              </span>
+            </div>
             <ul class="requirement-list mb-3">
               <li data-requirement="minlength"><i class="material-symbols-outlined">close</i>Mindestens 8 Zeichen</li>
               <li data-requirement="maxlength"><i class="material-symbols-outlined">close</i>Maximal 128 Zeichen</li>
@@ -219,7 +224,12 @@
           </div>
           <div class="mb-3">
             <label for="new_password_confirm" class="form-label">Passwort bestätigen</label>
-            <input type="password" class="form-control pw-confirm" id="new_password_confirm" name="new_password_confirm" required>
+            <div class="input-group">
+              <input type="password" class="form-control pw-confirm" id="new_password_confirm" name="new_password_confirm" required>
+              <span class="input-group-text" id="toggleNewPasswordConfirm" style="cursor: pointer;">
+                <span class="material-symbols-outlined">visibility</span>
+              </span>
+            </div>
           </div>
           <button type="submit" class="btn btn-primary">Speichern</button>
         </form>

--- a/templates/profile.tpl
+++ b/templates/profile.tpl
@@ -155,7 +155,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
       </div>
       <div class="modal-body">
-        <form method="post" action="{url path='update_profile'}">
+        <form method="post" action="{url path='update_profile'}" data-pw-validate>
           <input type="hidden" name="action" value="update_username">
           <div class="mb-3">
             <label for="new_username" class="form-label">Neuer Benutzername</label>
@@ -205,13 +205,21 @@
             <label for="current_password" class="form-label">Aktuelles Passwort</label>
             <input type="password" class="form-control" id="current_password" name="old_password" required>
           </div>
-          <div class="mb-3">
+          <div class="mb-3 pass-field">
             <label for="new_password" class="form-label">Neues Passwort</label>
-            <input type="password" class="form-control" id="new_password" name="new_password" required>
+            <input type="password" class="form-control pw-new" id="new_password" name="new_password" required>
+            <ul class="requirement-list mb-3">
+              <li data-requirement="minlength">Mindestens 8 Zeichen</li>
+              <li data-requirement="maxlength">Maximal 128 Zeichen</li>
+              <li data-requirement="number">Mindestens eine Zahl</li>
+              <li data-requirement="lowercase">Kleinbuchstabe</li>
+              <li data-requirement="uppercase">Großbuchstabe</li>
+              <li data-requirement="special">Sonderzeichen</li>
+            </ul>
           </div>
           <div class="mb-3">
             <label for="new_password_confirm" class="form-label">Passwort bestätigen</label>
-            <input type="password" class="form-control" id="new_password_confirm" name="new_password_confirm" required>
+            <input type="password" class="form-control pw-confirm" id="new_password_confirm" name="new_password_confirm" required>
           </div>
           <button type="submit" class="btn btn-primary">Speichern</button>
         </form>

--- a/templates/reset_password.tpl
+++ b/templates/reset_password.tpl
@@ -15,16 +15,34 @@
 {/if}
 
 {if !$success}
-<form method="post" class="needs-validation" novalidate>
+<form method="post" class="needs-validation" data-pw-validate novalidate>
     <div id="formAlert" class="alert alert-danger d-none">Bitte alle Felder ausfüllen.</div>
 
-    <div class="mb-3">
+    <div class="mb-3 pass-field">
         <label for="password" class="form-label">Neues Passwort</label>
-        <input type="password" class="form-control" id="password" name="password" required>
+        <div class="input-group">
+            <input type="password" class="form-control pw-new" id="password" name="password" required>
+            <span class="input-group-text" id="toggleResetPassword" style="cursor: pointer;">
+                <span class="material-symbols-outlined">visibility</span>
+            </span>
+        </div>
+        <ul class="requirement-list mb-3">
+          <li data-requirement="minlength"><i class="material-symbols-outlined">close</i>Mindestens 8 Zeichen</li>
+          <li data-requirement="maxlength"><i class="material-symbols-outlined">close</i>Maximal 128 Zeichen</li>
+          <li data-requirement="number"><i class="material-symbols-outlined">close</i>Mindestens eine Zahl</li>
+          <li data-requirement="lowercase"><i class="material-symbols-outlined">close</i>Kleinbuchstabe</li>
+          <li data-requirement="uppercase"><i class="material-symbols-outlined">close</i>Großbuchstabe</li>
+          <li data-requirement="special"><i class="material-symbols-outlined">close</i>Sonderzeichen</li>
+        </ul>
     </div>
     <div class="mb-3">
         <label for="password_confirm" class="form-label">Passwort bestätigen</label>
-        <input type="password" class="form-control" id="password_confirm" name="password_confirm" required>
+        <div class="input-group">
+            <input type="password" class="form-control pw-confirm" id="password_confirm" name="password_confirm" required>
+            <span class="input-group-text" id="toggleResetPasswordConfirm" style="cursor: pointer;">
+                <span class="material-symbols-outlined">visibility</span>
+            </span>
+        </div>
     </div>
     <button type="submit" class="btn btn-primary">Passwort speichern</button>
 </form>


### PR DESCRIPTION
## Summary
- add password requirement helper and include in config
- validate new passwords in `PasswordController::changePassword`
- reuse controller when updating profile password
- show requirement list on password change forms
- add generic password validation script and load it globally

## Testing
- `composer validate --no-check-lock`
- `php -l includes/password_requirements.inc.php`
- `php -l includes/config.inc.php`
- `php -l src/PasswordController.php`
- `php -l public/update_profile.php`
- `php -l public/passwort_change.php`
- `php -l templates/profile.tpl`
- `php -l templates/passwort_change.tpl`


------
https://chatgpt.com/codex/tasks/task_e_68641377f8f4833293d418f048b40490