### PR TITLE
Harden template outputs

### DIFF
--- a/templates/2fa_login.tpl
+++ b/templates/2fa_login.tpl
@@ -16,9 +16,9 @@
             {if isset($flash.message) || isset($message)}
                 <div class="alert alert-{if isset($flash.type)}{$flash.type|default:'info'}{else}danger{/if}">
                     {if isset($flash.message)}
-                        {$flash.message}
+                        {$flash.message|escape}
                     {else}
-                        {$message}
+                        {$message|escape}
                     {/if}
                 </div>
             {/if}

--- a/templates/2fa_setup.tpl
+++ b/templates/2fa_setup.tpl
@@ -5,7 +5,7 @@
     <h2 class="mb-3">Zwei-Faktor-Authentifizierung einrichten</h2>
 
     {if isset($message)}
-        <div class="alert alert-danger">{$message}</div>
+        <div class="alert alert-danger">{$message|escape}</div>
     {/if}
 
     <p>Scanne den folgenden QR-Code mit einer Authenticator-App wie z. B. <strong>Google Authenticator</strong> oder <strong>Authy</strong>:</p>

--- a/templates/group_create.tpl
+++ b/templates/group_create.tpl
@@ -3,8 +3,8 @@
 {block name="content"}
 <div class="container mt-5">
   <h1 class="mb-4 text-center">Neue Gruppe erstellen</h1>
-  {if $error}<div class="alert alert-danger">{$error}</div>{/if}
-  {if $success}<div class="alert alert-success">{$success}</div>{/if}
+  {if $error}<div class="alert alert-danger">{$error|escape}</div>{/if}
+  {if $success}<div class="alert alert-success">{$success|escape}</div>{/if}
   <form method="post">
     <div class="mb-3">
       <input type="text" name="group_name" class="form-control" placeholder="Gruppenname" required>

--- a/templates/groups.tpl
+++ b/templates/groups.tpl
@@ -6,8 +6,8 @@
 
   <h1 class="mb-4 text-center">Lerngruppen</h1>
 
-  {if $error}<div class="alert alert-danger">{$error}</div>{/if}
-  {if $success}<div class="alert alert-success">{$success}</div>{/if}
+  {if $error}<div class="alert alert-danger">{$error|escape}</div>{/if}
+  {if $success}<div class="alert alert-success">{$success|escape}</div>{/if}
 
  
 

--- a/templates/gruppe.tpl
+++ b/templates/gruppe.tpl
@@ -3,8 +3,8 @@
 
 {block name="content"}
 <div class="container mt-5">
-  {if $error}<div class="alert alert-danger">{$error}</div>{/if}
-  {if $success}<div class="alert alert-success">{$success}</div>{/if}
+  {if $error}<div class="alert alert-danger">{$error|escape}</div>{/if}
+  {if $success}<div class="alert alert-success">{$success|escape}</div>{/if}
 
   <div class="text-center mb-3">
     {if $group.group_picture}

--- a/templates/join_group.tpl
+++ b/templates/join_group.tpl
@@ -4,7 +4,7 @@
 {block name="content"}
   <div class="container my-5">
     <div class="alert alert-{$alertType} text-center" role="alert">
-      <p class="mb-3">{$message}</p>
+      <p class="mb-3">{$message|escape}</p>
       {if $showButton}
         <a href="{$buttonLink}" class="btn btn-primary">{$buttonText}</a>
       {/if}

--- a/templates/my_groups.tpl
+++ b/templates/my_groups.tpl
@@ -4,8 +4,8 @@
 {block name="content"}
 <div class="container mt-5">
   <h1 class="mb-4 text-center">Meine Lerngruppen</h1>
-  {if $error}<div class="alert alert-danger">{$error}</div>{/if}
-  {if $success}<div class="alert alert-success">{$success}</div>{/if}
+  {if $error}<div class="alert alert-danger">{$error|escape}</div>{/if}
+  {if $success}<div class="alert alert-success">{$success|escape}</div>{/if}
 
   {if $myGroups|@count > 0}
     <div class="mb-3">

--- a/templates/passwort_change.tpl
+++ b/templates/passwort_change.tpl
@@ -7,7 +7,7 @@
 {if $success}
     <div class="alert alert-success">Passwort wurde aktualisiert.</div>
 {elseif $message}
-    <div class="alert alert-danger">{$message}</div>
+    <div class="alert alert-danger">{$message|escape}</div>
 {/if}
 <div id="formAlert" class="alert alert-danger d-none">Bitte alle Felder ausfüllen.</div>
 <form method="post" class="needs-validation" data-pw-validate novalidate>

--- a/templates/pending_uploads.tpl
+++ b/templates/pending_uploads.tpl
@@ -3,7 +3,7 @@
 
 {if $flash}
   <div class="alert alert-{$flash.type} alert-dismissible fade show" role="alert">
-    {$flash.message}
+    {$flash.message|escape}
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Schließen"></button>
   </div>
 {/if}

--- a/templates/request_password_reset.tpl
+++ b/templates/request_password_reset.tpl
@@ -7,7 +7,7 @@
 {if $success}
     <div class="alert alert-success">E-Mail wurde versendet.</div>
 {elseif $message}
-    <div class="alert alert-danger">{$message}</div>
+    <div class="alert alert-danger">{$message|escape}</div>
 {/if}
 <div id="formAlert" class="alert alert-danger d-none">Bitte alle Felder ausfüllen.</div>
 <form method="post" class="needs-validation" novalidate>

--- a/templates/reset_password.tpl
+++ b/templates/reset_password.tpl
@@ -11,7 +11,7 @@
 {/if}
 
 {if $message}
-    <div class="alert alert-danger">{$message}</div>
+    <div class="alert alert-danger">{$message|escape}</div>
 {/if}
 
 {if !$success}

--- a/templates/upload.tpl
+++ b/templates/upload.tpl
@@ -6,13 +6,13 @@
     <h1 class="mb-4 text-center">Materialien hochladen</h1>
 
     {if isset($error)}
-    <div class="alert alert-danger">{$error}</div>
+    <div class="alert alert-danger">{$error|escape}</div>
     {/if}
     {if isset($warning)}
-    <div class="alert alert-warning">{$warning}</div>
+    <div class="alert alert-warning">{$warning|escape}</div>
     {/if}
     {if isset($success)}
-    <div class="alert alert-success">{$success}</div>
+    <div class="alert alert-success">{$success|escape}</div>
     {/if}
 
     <div class="mb-3">

--- a/templates/verify.tpl
+++ b/templates/verify.tpl
@@ -5,7 +5,7 @@
 {block name="content"}
   <div class="container my-5">
     <div class="alert alert-{$alertType} text-center" role="alert">
-      <p class="mb-3">{$message}</p>
+      <p class="mb-3">{$message|escape}</p>
       {if $showButton}
         <a href="{$buttonLink}" class="btn btn-primary">{$buttonText}</a>
       {/if}


### PR DESCRIPTION
## Summary
- escape dynamic flash/message outputs across templates

## Testing
- `composer install`
- `php -l public/upload.php`

------
https://chatgpt.com/codex/tasks/task_e_6864cbc2e04883328b7b0fb345f4d7f9