### PR TITLE
Fix missing include for password changes

### DIFF
--- a/public/update_profile.php
+++ b/public/update_profile.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../includes/config.inc.php';
+require_once __DIR__ . '/../src/PasswordController.php';
 
 if (empty($_SESSION['user_id'])) {
     $reason = 'Nicht eingeloggt.';


### PR DESCRIPTION
## Summary
- include the PasswordController in `update_profile.php` so that password changes work

## Testing
- `php -l public/update_profile.php`
- `find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6865485938148332beef5b29c99fd0ae