### PR TITLE
Add missing comments

### DIFF
--- a/includes/crypto.inc.php
+++ b/includes/crypto.inc.php
@@ -5,15 +5,25 @@ use ParagonIE\Halite\Symmetric\EncryptionKey;
 use ParagonIE\HiddenString\HiddenString;
 use ParagonIE\Halite\Symmetric\Crypto as HaliteCrypto;
 
+/**
+ * Erstellt einen sicheren Hash eines Passworts.
+ */
 function hashPassword(string $password): string
 {
     return password_hash($password, PASSWORD_DEFAULT);
 }
+
+/**
+ * Vergleicht ein Passwort mit seinem Hash.
+ */
 function verifyPassword(string $password, string $hash): bool
 {
     return password_verify($password, $hash);
 }
 
+/**
+ * Liefert den in der Konfiguration hinterlegten Halite-Schlüssel.
+ */
 function getCryptoKey(): EncryptionKey
 {
     global $config;
@@ -24,11 +34,17 @@ function getCryptoKey(): EncryptionKey
     return $key;
 }
 
+/**
+ * Verschlüsselt Klartext mit dem Halite-Key.
+ */
 function encryptData(string $plainText): string
 {
     return HaliteCrypto::encrypt(new HiddenString($plainText), getCryptoKey());
 }
 
+/**
+ * Entschlüsselt zuvor verschlüsselte Daten.
+ */
 function decryptData(string $cipherText): HiddenString
 {
     try {

--- a/includes/db.inc.php
+++ b/includes/db.inc.php
@@ -2325,6 +2325,9 @@ public static function getFilteredLockedUsers(array $filters = []): array
         return $profile ?: [];
     }
 
+    /**
+     * Aktualisiert das Benutzerprofil mit den angegebenen Feldern.
+     */
     public static function updateUserProfile(int $userId, array $fields): void
     {
         $pdo = self::db_connect();
@@ -2353,6 +2356,9 @@ public static function getFilteredLockedUsers(array $filters = []): array
         }
     }
 
+    /**
+     * Speichert Änderungen an einer Gruppe.
+     */
     public static function updateGroup(int $groupId, array $fields): void
     {
         $pdo = self::db_connect();

--- a/includes/group_invites.inc.php
+++ b/includes/group_invites.inc.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/mailing.inc.php';
 
+/**
+ * Versendet eine Einladung zu einer Lerngruppe per E-Mail.
+ */
 function sendGroupInviteEmail(string $toEmail, string $toName, string $groupName, string $inviterName, string $token): void
 {
     global $config;

--- a/includes/password_requirements.inc.php
+++ b/includes/password_requirements.inc.php
@@ -1,4 +1,13 @@
 <?php
+
+/**
+ * Prüft, ob ein Passwort die Mindestanforderungen erfüllt.
+ *
+ * Anforderungen:
+ *  - Länge zwischen 8 und 128 Zeichen
+ *  - Mindestens eine Ziffer, ein Groß‑ und Kleinbuchstabe
+ *  - Mindestens ein Sonderzeichen
+ */
 function password_meets_requirements(string $password): bool {
     $lengthOk = preg_match('/^.{8,128}$/', $password) === 1;
     $hasNumber = preg_match('/[0-9]/', $password) === 1;

--- a/includes/password_reset.inc.php
+++ b/includes/password_reset.inc.php
@@ -33,6 +33,9 @@ function sendPasswordResetEmail(
     sendMail($email, $username, $subject, $htmlBody, $altBody);
 }
 
+/**
+ * Benachrichtigt den Nutzer über ein erfolgreiches Zurücksetzen.
+ */
 function sendPasswordResetSuccessEmail (
     PDO $pdo,
     int $userId,

--- a/includes/pdf_utils.inc.php
+++ b/includes/pdf_utils.inc.php
@@ -46,6 +46,9 @@ function convert_file_to_pdf(string $sourcePath, string $destPath): bool
     return true;
 }
 
+/**
+ * Extrahiert einfachen Text aus einer DOCX-Datei.
+ */
 function extract_text_from_docx(string $file): string
 {
     $zip = new ZipArchive();
@@ -59,6 +62,9 @@ function extract_text_from_docx(string $file): string
     return '';
 }
 
+/**
+ * Extrahiert Text aus allen Folien einer PPTX-Datei.
+ */
 function extract_text_from_pptx(string $file): string
 {
     $zip = new ZipArchive();

--- a/src/PasswordController.php
+++ b/src/PasswordController.php
@@ -2,8 +2,14 @@
 require_once __DIR__ . '/../includes/config.inc.php';
 require_once __DIR__ . '/../includes/password_reset.inc.php';
 
+/**
+ * Stellt Funktionen zum Zurücksetzen und Ändern von Passwörtern bereit.
+ */
 class PasswordController
 {
+    /**
+     * Startet den Reset-Prozess und versendet eine E-Mail mit Token.
+     */
     public static function requestReset(string $identifier): void
     {
         $user = DbFunctions::fetchUserByIdentifier($identifier);
@@ -16,6 +22,9 @@ class PasswordController
         sendPasswordResetEmail(DbFunctions::db_connect(), (int)$user['id'], $user['username'], $user['email'], $token);
     }
 
+    /**
+     * Setzt das Passwort anhand eines gültigen Tokens zurück.
+     */
     public static function resetPassword(string $token, string $password): void
     {
         $user = DbFunctions::fetchPasswordResetUser($token);
@@ -31,6 +40,9 @@ class PasswordController
         sendPasswordResetSuccessEmail(DbFunctions::db_connect(), (int)$user['id'], $user['username'], $user['email']);
     }
 
+    /**
+     * Ändert das Passwort eines angemeldeten Benutzers.
+     */
     public static function changePassword(int $userId, string $oldPassword, string $newPassword): void
     {
         $user = DbFunctions::fetchUserById($userId);


### PR DESCRIPTION
## Summary
- document `password_meets_requirements`
- add docblocks for crypto helpers
- explain group invite mail helper
- add missing docs for pdf utilities
- document password reset success email
- document user profile and group updates
- document password controller methods

## Testing
- `php -l includes/password_requirements.inc.php`
- `php -l includes/crypto.inc.php`
- `php -l includes/group_invites.inc.php`
- `php -l includes/pdf_utils.inc.php`
- `php -l includes/password_reset.inc.php`
- `php -l includes/db.inc.php`
- `php -l src/PasswordController.php`


------
https://chatgpt.com/codex/tasks/task_e_686554a87a64833294b748be67432d74